### PR TITLE
Removed NetworkAttachmentSpec.VNI

### DIFF
--- a/staging/kos/pkg/apis/network/types.go
+++ b/staging/kos/pkg/apis/network/types.go
@@ -34,10 +34,6 @@ type NetworkAttachmentSpec struct {
 
 	// Subnet is the object name of the subnet of this attachment
 	Subnet string
-
-	// VNI identifies the virtual network this NetworkAttachment belongs to.
-	// Valid values are in the range [1,2097151].
-	VNI uint32
 }
 
 type NetworkAttachmentStatus struct {

--- a/staging/kos/pkg/apis/network/v1alpha1/register.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/register.go
@@ -68,7 +68,7 @@ func addFieldConversions(scheme *runtime.Scheme) error {
 
 func convertNetworkAttachmentFields(label, value string) (internalLabel, internalValue string, err error) {
 	switch label {
-	case "metadata.name", "metadata.namespace", "spec.node", "spec.subnet", "spec.vni", "status.ipv4", "status.hostIP", "status.addressVNI":
+	case "metadata.name", "metadata.namespace", "spec.node", "spec.subnet", "status.ipv4", "status.hostIP", "status.addressVNI":
 		return label, value, nil
 	default:
 		return "", "", fmt.Errorf("NetworkAttachment does not have field with label %q", label)

--- a/staging/kos/pkg/apis/network/v1alpha1/types.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/types.go
@@ -34,10 +34,6 @@ type NetworkAttachmentSpec struct {
 
 	// Subnet is the object name of the subnet of this attachment
 	Subnet string `json:"subnet" protobuf:"bytes,2,name=subnet"`
-
-	// VNI identifies the virtual network this NetworkAttachment belongs to.
-	// Valid values are in the range [1,2097151].
-	VNI uint32 `json:"vni" protobuf:"bytes,3,name=vni"`
 }
 
 type NetworkAttachmentStatus struct {

--- a/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
@@ -210,7 +210,6 @@ func Convert_network_NetworkAttachmentList_To_v1alpha1_NetworkAttachmentList(in 
 func autoConvert_v1alpha1_NetworkAttachmentSpec_To_network_NetworkAttachmentSpec(in *NetworkAttachmentSpec, out *network.NetworkAttachmentSpec, s conversion.Scope) error {
 	out.Node = in.Node
 	out.Subnet = in.Subnet
-	out.VNI = in.VNI
 	return nil
 }
 
@@ -222,7 +221,6 @@ func Convert_v1alpha1_NetworkAttachmentSpec_To_network_NetworkAttachmentSpec(in 
 func autoConvert_network_NetworkAttachmentSpec_To_v1alpha1_NetworkAttachmentSpec(in *network.NetworkAttachmentSpec, out *NetworkAttachmentSpec, s conversion.Scope) error {
 	out.Node = in.Node
 	out.Subnet = in.Subnet
-	out.VNI = in.VNI
 	return nil
 }
 

--- a/staging/kos/pkg/registry/network/networkattachment/strategy.go
+++ b/staging/kos/pkg/registry/network/networkattachment/strategy.go
@@ -64,7 +64,6 @@ func SelectableFields(obj *network.NetworkAttachment) fields.Set {
 		fields.Set{
 			"spec.node":         obj.Spec.Node,
 			"spec.subnet":       obj.Spec.Subnet,
-			"spec.vni":          strconv.FormatUint(uint64(obj.Spec.VNI), 10),
 			"status.ipv4":       obj.Status.IPv4,
 			"status.hostIP":     obj.Status.HostIP,
 			"status.addressVNI": strconv.FormatUint(uint64(obj.Status.AddressVNI), 10),


### PR DESCRIPTION
Made connection agent select remote NetworkAttachments based on
NetworkAttachmentStatus.AddressVNI rather than
NetworkAttachmentSpec.VNI, rendering the latter useless.