### PR TITLE
Remove host IP from local interface

### DIFF
--- a/staging/kos/pkg/controllers/connectionagent/connectionagent.go
+++ b/staging/kos/pkg/controllers/connectionagent/connectionagent.go
@@ -830,7 +830,7 @@ func (ca *ConnectionAgent) createOrUpdateIfc(attGuestIP, attHostIP gonet.IP, att
 	oldLocalState, attHasLocalIfc := ca.getLocalAttState(attNSN)
 	oldRemoteIfc, attHasRemoteIfc := ca.getRemoteIfc(attNSN)
 	newIfcNeedsToBeCreated := (!attHasLocalIfc && !attHasRemoteIfc) ||
-		(attHasLocalIfc && ifcNeedsUpdate(oldLocalState.HostIP, attHostIP, oldLocalState.GuestMAC, attMAC)) ||
+		(attHasLocalIfc && ifcNeedsUpdate(ca.hostIP, attHostIP, oldLocalState.GuestMAC, attMAC)) ||
 		(attHasRemoteIfc && ifcNeedsUpdate(oldRemoteIfc.HostIP, attHostIP, oldRemoteIfc.GuestMAC, attMAC))
 
 	if newIfcNeedsToBeCreated {
@@ -860,7 +860,6 @@ func (ca *ConnectionAgent) createOrUpdateIfc(attGuestIP, attHostIP gonet.IP, att
 					VNI:      attVNI,
 					GuestMAC: attMAC,
 					GuestIP:  attGuestIP,
-					HostIP:   attHostIP,
 				},
 				PostDeleteExec: PostDeleteExec,
 			}

--- a/staging/kos/pkg/networkfabric/interfaces.go
+++ b/staging/kos/pkg/networkfabric/interfaces.go
@@ -34,15 +34,14 @@ type Interface interface {
 	ListRemoteIfcs() ([]RemoteNetIfc, error)
 }
 
-type RemoteNetIfc struct {
+type LocalNetIfc struct {
+	Name     string
 	VNI      uint32
 	GuestMAC net.HardwareAddr
 	GuestIP  net.IP
-	HostIP   net.IP
 }
 
-type LocalNetIfc struct {
-	Name     string
+type RemoteNetIfc struct {
 	VNI      uint32
 	GuestMAC net.HardwareAddr
 	GuestIP  net.IP


### PR DESCRIPTION
The netowork fabric local interfaces don't need a field for the host IP. This PR removes such field and updates the connection agent to no longer set it/use it.