### PR TITLE
Small fixes

### DIFF
--- a/staging/kos/cmd/attachment-tput-driver/test-scripts/TestByPing
+++ b/staging/kos/cmd/attachment-tput-driver/test-scripts/TestByPing
@@ -14,6 +14,7 @@ peer_name=$6
 ip link show $ifc_name || exit 2
 ip netns add $netns_name
 ip link set $ifc_name netns $netns_name
+ip netns exec $netns_name ip link set $ifc_name up
 ip netns exec $netns_name ip addr add $ifc_ip dev $ifc_name
 ip netns exec $netns_name ip addr
 ip netns exec $netns_name ip route

--- a/staging/kos/deploy.m4/main/50-ds-ca.yaml.m4
+++ b/staging/kos/deploy.m4/main/50-ds-ca.yaml.m4
@@ -16,6 +16,7 @@ spec:
         prometheus.io/port: "9294"
     spec:
       serviceAccountName: connection-agent
+      hostNetwork: true
       containers:
       - name: connection-agent
         image: DOCKER_PREFIX/kos-connection-agent:latest


### PR DESCRIPTION
Make connection agent run in host network namespace.

Also, add instruction that sets the interface used for pinging up in testByPing.