### PR TITLE
Remove Prometheus job kubernetes-nodes

### DIFF
--- a/staging/kos/metrics/prometheus/config/config.yaml
+++ b/staging/kos/metrics/prometheus/config/config.yaml
@@ -40,37 +40,6 @@ scrape_configs:
     action: keep
     regex: default;kubernetes;https
 
-# Based on https://github.com/prometheus/prometheus/blob/63fe65bf2ff8c480bb4350e4d278d3208ca687be/documentation/examples/prometheus-kubernetes.yml#L50-L78
-- job_name: 'kubernetes-nodes'
-
-  # Default to scraping over https. If required, just disable this or change to
-  # `http`.
-  scheme: https
-
-  # This TLS & bearer token file config is used to connect to the actual scrape
-  # endpoints for cluster components. This is separate to discovery auth
-  # configuration because discovery & scraping are two separate concerns in
-  # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-  # the cluster. Otherwise, more config options have to be provided within the
-  # <kubernetes_sd_config>.
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    # If your node certificates are self-signed or use a different CA to the
-    # master CA, then disable certificate verification below. Note that
-    # certificate verification is an integral part of a secure infrastructure
-    # so this should only be disabled in a controlled environment. You can
-    # disable certificate verification by uncommenting the line below.
-    #
-    # insecure_skip_verify: true
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
-  kubernetes_sd_configs:
-  - role: node
-
-  relabel_configs:
-  - action: labelmap
-    regex: __meta_kubernetes_node_label_(.+)
-
 
 - job_name: 'kubernetes-nodes-cadvisor'
   tls_config:
@@ -168,3 +137,6 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
     target_label: kubernetes_pod_name
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    action: replace
+    target_label: node_name

--- a/staging/kos/metrics/prometheus/manifests/configmap.yaml
+++ b/staging/kos/metrics/prometheus/manifests/configmap.yaml
@@ -46,37 +46,6 @@ data:
         action: keep
         regex: default;kubernetes;https
     
-    # Based on https://github.com/prometheus/prometheus/blob/63fe65bf2ff8c480bb4350e4d278d3208ca687be/documentation/examples/prometheus-kubernetes.yml#L50-L78
-    - job_name: 'kubernetes-nodes'
-    
-      # Default to scraping over https. If required, just disable this or change to
-      # `http`.
-      scheme: https
-    
-      # This TLS & bearer token file config is used to connect to the actual scrape
-      # endpoints for cluster components. This is separate to discovery auth
-      # configuration because discovery & scraping are two separate concerns in
-      # Prometheus. The discovery auth config is automatic if Prometheus runs inside
-      # the cluster. Otherwise, more config options have to be provided within the
-      # <kubernetes_sd_config>.
-      tls_config:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        # If your node certificates are self-signed or use a different CA to the
-        # master CA, then disable certificate verification below. Note that
-        # certificate verification is an integral part of a secure infrastructure
-        # so this should only be disabled in a controlled environment. You can
-        # disable certificate verification by uncommenting the line below.
-        #
-        # insecure_skip_verify: true
-      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-    
-      kubernetes_sd_configs:
-      - role: node
-    
-      relabel_configs:
-      - action: labelmap
-        regex: __meta_kubernetes_node_label_(.+)
-    
     
     - job_name: 'kubernetes-nodes-cadvisor'
       tls_config:
@@ -174,3 +143,6 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: node_name


### PR DESCRIPTION
The kubelet metrics are not very interesting to us.

Also add a target label `node_name` to the kubernetes-pods job, because not all tagets were getting the inexplicable `node` label.