### PR TITLE
Immutability follow up

### DIFF
--- a/staging/kos/pkg/controllers/subnet/validator.go
+++ b/staging/kos/pkg/controllers/subnet/validator.go
@@ -166,12 +166,12 @@ func (v *Validator) OnUpdate(oldObj, newObj interface{}) {
 	// status updates from this controller so that all the processing which was
 	// not performed because the subnet in the Informer's cache was stale can be
 	// performed.
-	if oldS.UID != newS.UID || v.subnetIsAwaited(nsn, newS.ResourceVersion) {
+	if oldS.UID != newS.UID || v.subnetIsStaleNoMore(nsn, newS.ResourceVersion) {
 		v.queue.Add(nsn)
 	}
 }
 
-func (v *Validator) subnetIsAwaited(subnet k8stypes.NamespacedName, rv string) bool {
+func (v *Validator) subnetIsStaleNoMore(subnet k8stypes.NamespacedName, rv string) bool {
 	v.staleRVsMutex.RLock()
 	defer v.staleRVsMutex.RUnlock()
 


### PR DESCRIPTION
Complete work in https://github.com/MikeSpreitzer/kube-examples/pull/67# by:

1) Implementing the rename suggested in https://github.com/MikeSpreitzer/kube-examples/pull/67#discussion_r301204919.

2) Performing the following changes to the README:
- Say that spec fields are immutable in Subnet and NetworkAttachment descriptions.
- Move the two paragraphs talking about the lack of interlocks from the IPAM controller section to the SDN section giving them more prominence: they are relevant to the whole KOS (especially after immutability), not just the IPAM.
- Replace "subnet updates" with "subnet deletion followed by creation with same namespaced name" in subnet validation controller section.
- Update IPAM controller duplicate work suppression paragraph: after immutability Subnets'UIDs are used rather than RVs.