### PR TITLE
Paid some technical debt

### DIFF
--- a/staging/kos/README.md
+++ b/staging/kos/README.md
@@ -497,15 +497,17 @@ building and operations.
 There is a `Makefile` in the `kos` directory and it supports some of
 the following steps.
 
-### Dependency Management
+### Dependencies
 
 Dependencies are managed via [Glide](https://github.com/Masterminds/glide).
+
+This example builds against release 1.14 of Kubernetes.
 
 ### Pre-Requisites
 
 You will need the following installed on your build/ops machine.
 
-- Go, release 1.10 or later
+- Go, release 1.12.1 or later
 
 - Docker
 

--- a/staging/kos/deploy/etcd-operator-rbac/47-eo-role.yaml
+++ b/staging/kos/deploy/etcd-operator-rbac/47-eo-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kos-etcd-operator

--- a/staging/kos/deploy/etcd-operator-rbac/47-eo-rolebind.yaml
+++ b/staging/kos/deploy/etcd-operator-rbac/47-eo-rolebind.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kos-etcd-operator

--- a/staging/kos/deploy/etcd-operator/47-eo-theop.yaml
+++ b/staging/kos/deploy/etcd-operator/47-eo-theop.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: etcd-operator
   namespace: example-com
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: etcd-operator
   template:
     metadata:
       labels:
@@ -20,7 +23,7 @@ spec:
         role.kos.example.com/control: "true"
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.9.3
+        image: quay.io/coreos/etcd-operator:v0.9.4
         command:
         - etcd-operator
         # Uncomment to act for resources in all namespaces. More information in doc/user/clusterwide.md

--- a/staging/kos/deploy/main/70-apiservice.yaml
+++ b/staging/kos/deploy/main/70-apiservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.network.example.com

--- a/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
+++ b/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
+  "id": 7,
   "links": [],
   "panels": [
     {
@@ -237,6 +237,13 @@
           "intervalFactor": 1,
           "legendFormat": "ipam @ {{ instance }}",
           "refId": "B"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_queue_retries[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "snval @ {{ instance }}",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -329,6 +336,13 @@
           "intervalFactor": 1,
           "legendFormat": "ipam @ {{ instance }}",
           "refId": "B"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_queue_adds[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "snval @ {{ instance }}",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -421,6 +435,13 @@
           "intervalFactor": 1,
           "legendFormat": "ipam @ {{ instance }}",
           "refId": "B"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_queue_queue_latency_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "snval @ {{ instance }}",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -513,6 +534,13 @@
           "intervalFactor": 1,
           "legendFormat": "ipam @ {{ instance }}",
           "refId": "B"
+        },
+        {
+          "expr": "kos_subnet_validator_queue_depth",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "snval @ {{ instance }}",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -561,6 +589,90 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 34,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Worker Utilization",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "prometheus",
       "description": "Sum, over workers, of utilization of that worker",
       "fill": 1,
@@ -568,7 +680,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 41
       },
       "id": 25,
       "legend": {
@@ -653,7 +765,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 48
       },
       "id": 27,
       "legend": {
@@ -745,7 +857,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 55
       },
       "id": 28,
       "legend": {
@@ -837,7 +949,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 62
       },
       "id": 30,
       "legend": {
@@ -929,7 +1041,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 69
       },
       "id": 32,
       "legend": {
@@ -1021,7 +1133,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 76
       },
       "id": 4,
       "legend": {
@@ -1106,7 +1218,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 77
+        "y": 83
       },
       "id": 29,
       "legend": {
@@ -1191,7 +1303,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 84
+        "y": 90
       },
       "id": 31,
       "legend": {
@@ -1276,7 +1388,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 91
+        "y": 97
       },
       "id": 5,
       "legend": {
@@ -1361,7 +1473,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 98
+        "y": 104
       },
       "id": 6,
       "legend": {
@@ -1446,7 +1558,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 111
       },
       "id": 12,
       "legend": {
@@ -1531,7 +1643,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 112
+        "y": 118
       },
       "id": 14,
       "legend": {
@@ -1616,7 +1728,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 119
+        "y": 125
       },
       "id": 15,
       "legend": {
@@ -1701,7 +1813,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 126
+        "y": 132
       },
       "id": 16,
       "legend": {
@@ -1786,7 +1898,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 133
+        "y": 139
       },
       "id": 17,
       "legend": {
@@ -1871,7 +1983,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 140
+        "y": 146
       },
       "id": 7,
       "legend": {
@@ -1970,7 +2082,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 147
+        "y": 153
       },
       "id": 18,
       "legend": {
@@ -2055,7 +2167,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 154
+        "y": 160
       },
       "id": 19,
       "legend": {
@@ -2169,5 +2281,5 @@
   "timezone": "",
   "title": "KOS Internals",
   "uid": "39Dk0_Qik",
-  "version": 2
+  "version": 1
 }

--- a/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
+++ b/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
@@ -4964,7 +4964,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 3,
+      "id": 7,
       "links": [],
       "panels": [
         {
@@ -5186,6 +5186,13 @@ data:
               "intervalFactor": 1,
               "legendFormat": "ipam @ {{ instance }}",
               "refId": "B"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_queue_retries[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "snval @ {{ instance }}",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -5278,6 +5285,13 @@ data:
               "intervalFactor": 1,
               "legendFormat": "ipam @ {{ instance }}",
               "refId": "B"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_queue_adds[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "snval @ {{ instance }}",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -5370,6 +5384,13 @@ data:
               "intervalFactor": 1,
               "legendFormat": "ipam @ {{ instance }}",
               "refId": "B"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_queue_queue_latency_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "snval @ {{ instance }}",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -5462,6 +5483,13 @@ data:
               "intervalFactor": 1,
               "legendFormat": "ipam @ {{ instance }}",
               "refId": "B"
+            },
+            {
+              "expr": "kos_subnet_validator_queue_depth",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "snval @ {{ instance }}",
+              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -5510,6 +5538,90 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
+          "fill": 1,
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 35
+          },
+          "id": 34,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Worker Utilization",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": "prometheus",
           "description": "Sum, over workers, of utilization of that worker",
           "fill": 1,
@@ -5517,7 +5629,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 41
           },
           "id": 25,
           "legend": {
@@ -5602,7 +5714,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 48
           },
           "id": 27,
           "legend": {
@@ -5694,7 +5806,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 55
           },
           "id": 28,
           "legend": {
@@ -5786,7 +5898,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 56
+            "y": 62
           },
           "id": 30,
           "legend": {
@@ -5878,7 +5990,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 63
+            "y": 69
           },
           "id": 32,
           "legend": {
@@ -5970,7 +6082,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 70
+            "y": 76
           },
           "id": 4,
           "legend": {
@@ -6055,7 +6167,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 77
+            "y": 83
           },
           "id": 29,
           "legend": {
@@ -6140,7 +6252,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 84
+            "y": 90
           },
           "id": 31,
           "legend": {
@@ -6225,7 +6337,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 91
+            "y": 97
           },
           "id": 5,
           "legend": {
@@ -6310,7 +6422,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 98
+            "y": 104
           },
           "id": 6,
           "legend": {
@@ -6395,7 +6507,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 105
+            "y": 111
           },
           "id": 12,
           "legend": {
@@ -6480,7 +6592,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 112
+            "y": 118
           },
           "id": 14,
           "legend": {
@@ -6565,7 +6677,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 119
+            "y": 125
           },
           "id": 15,
           "legend": {
@@ -6650,7 +6762,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 126
+            "y": 132
           },
           "id": 16,
           "legend": {
@@ -6735,7 +6847,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 133
+            "y": 139
           },
           "id": 17,
           "legend": {
@@ -6820,7 +6932,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 140
+            "y": 146
           },
           "id": 7,
           "legend": {
@@ -6919,7 +7031,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 147
+            "y": 153
           },
           "id": 18,
           "legend": {
@@ -7004,7 +7116,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 154
+            "y": 160
           },
           "id": 19,
           "legend": {
@@ -7118,7 +7230,7 @@ data:
       "timezone": "",
       "title": "KOS Internals",
       "uid": "39Dk0_Qik",
-      "version": 2
+      "version": 1
     }
   kubernetes-apiservers.json: |
     {

--- a/staging/kos/pkg/controllers/ipam/ipam.go
+++ b/staging/kos/pkg/controllers/ipam/ipam.go
@@ -20,14 +20,12 @@ import (
 	"errors"
 	"fmt"
 	gonet "net"
-	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	k8scorev1api "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,13 +56,6 @@ const (
 	opCreation = "creation"
 	opUpdate   = "update"
 	opDeletion = "deletion"
-
-	// The HTTP port under which the scraping endpoint ("/metrics") is served.
-	// See https://github.com/prometheus/prometheus/wiki/Default-port-allocations .
-	MetricsAddr = ":9295"
-
-	// The HTTP path under which the scraping endpoint ("/metrics") is served.
-	MetricsPath = "/metrics"
 
 	// The namespace and subsystem of the Prometheus metrics produced here
 	MetricsNamespace = "kos"
@@ -233,12 +224,6 @@ func (ctlr *IPAMController) Run(stopCh <-chan struct{}) error {
 
 	klog.Info("Starting IPAM controller.")
 	defer klog.Info("Shutting down IPAM controller.")
-
-	// Serve Prometheus metrics
-	http.Handle("/metrics", promhttp.Handler())
-	go func() {
-		klog.Errorf("In-process HTTP server crashed: %s", http.ListenAndServe(MetricsAddr, nil).Error())
-	}()
 
 	ctlr.subnetInformer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
 		ctlr.OnSubnetCreate,


### PR DESCRIPTION
Updated some manifests to the latest API version.

Fixed breakage of controller manager not exporting workqueue metrics.

Added some visualization of metrics from subnet validator workqueue.

Added explicit note of the relevant Kubernetes release.