### PR TITLE
Make Subnet Validator Observable

### DIFF
--- a/staging/kos/cmd/connection-agent/main.go
+++ b/staging/kos/cmd/connection-agent/main.go
@@ -26,7 +26,6 @@ import (
 	"syscall"
 	"time"
 
-
 	k8scorev1api "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "k8s.io/client-go/kubernetes"
@@ -51,7 +50,7 @@ const (
 	defaultClientQPS   = 100
 	defaultClientBurst = 200
 
-	queueName = "kos_agent_queue"
+	queueName = "ca"
 )
 
 func main() {

--- a/staging/kos/cmd/controller-manager/main.go
+++ b/staging/kos/cmd/controller-manager/main.go
@@ -43,19 +43,10 @@ import (
 const (
 	// The HTTP port under which the scraping endpoint ("/metrics") is served.
 	// See https://github.com/prometheus/prometheus/wiki/Default-port-allocations .
-	MetricsAddr = ":9295"
-)
-
-const (
-	// The HTTP port under which the scraping endpoint ("/metrics") is served.
-	// See https://github.com/prometheus/prometheus/wiki/Default-port-allocations .
 	metricsAddr = ":9295"
 
 	// The HTTP path under which the scraping endpoint ("/metrics") is served.
 	metricsPath = "/metrics"
-
-	// The namespace and subsystem of the Prometheus metrics produced here
-	metricsNamespace = "kos"
 )
 
 func main() {
@@ -94,10 +85,9 @@ func main() {
 	}
 
 	ctx := controllerContext{
-		options:          ctlrOpts,
-		metricsNamespace: metricsNamespace,
-		sharedInformers:  kosinformers.NewSharedInformerFactory(kosInformersClientset, 0),
-		stop:             stopOnSignals(),
+		options:         ctlrOpts,
+		sharedInformers: kosinformers.NewSharedInformerFactory(kosInformersClientset, 0),
+		stop:            stopOnSignals(),
 	}
 	for controller, startController := range managedControllers {
 		k8sCC := addUserAgent(k8sClientCfg, controller)

--- a/staging/kos/cmd/controller-manager/options.go
+++ b/staging/kos/cmd/controller-manager/options.go
@@ -29,6 +29,7 @@ const (
 // KOS controllers.
 type KOSControllerManagerOptions struct {
 	KubeconfigFilename string
+	Hostname           string
 	QPS                int
 	Burst              int
 	IndirectRequests   bool
@@ -41,6 +42,7 @@ type KOSControllerManagerOptions struct {
 // controllers.
 func (o *KOSControllerManagerOptions) AddFlags() {
 	flag.StringVar(&o.KubeconfigFilename, "kubeconfig", "", "kubeconfig filename")
+	flag.StringVar(&o.Hostname, "hostname", "", "name of the host")
 	flag.IntVar(&o.QPS, "qps", defaultQPS, "QPS to use while talking to the api-servers")
 	flag.IntVar(&o.Burst, "burst", defaultBurst, "Burst to use while talking to the api-servers")
 	flag.BoolVar(&o.IndirectRequests, "indirect-requests", defaultIndirectRequests, "requests go through main api-servers instead of directly to network api-servers")

--- a/staging/kos/cmd/controller-manager/start_functions.go
+++ b/staging/kos/cmd/controller-manager/start_functions.go
@@ -33,11 +33,6 @@ import (
 	_ "k8s.io/examples/staging/kos/pkg/controllers/workqueue_prometheus"
 )
 
-const (
-	ipamMetricsSubsystem            = "ipam"
-	subnetValidatorMetricsSubsystem = "subnet_validator"
-)
-
 var managedControllers map[string]startFunction
 
 func init() {
@@ -48,10 +43,9 @@ func init() {
 }
 
 type controllerContext struct {
-	options          *KOSControllerManagerOptions
-	metricsNamespace string
-	sharedInformers  kosinformers.SharedInformerFactory
-	stop             <-chan struct{}
+	options         *KOSControllerManagerOptions
+	sharedInformers kosinformers.SharedInformerFactory
+	stop            <-chan struct{}
 }
 
 type startFunction func(ctx controllerContext, k8sClientCfg, kosClientCfg *rest.Config) error
@@ -82,8 +76,6 @@ func startIPAMController(ctx controllerContext, k8sClientCfg, kosClientCfg *rest
 		workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(200*time.Millisecond, 8*time.Hour), "kos_ipam_controller_queue"),
 		ctx.options.IPAMControllerWorkers,
 		ctx.options.Hostname,
-		ctx.metricsNamespace,
-		ipamMetricsSubsystem,
 	)
 
 	// Start the controller.
@@ -118,8 +110,6 @@ func startSubnetValidationController(ctx controllerContext, k8sClientCfg, kosCli
 		workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(200*time.Millisecond, 8*time.Hour), "kos_subnet_validator_queue"),
 		ctx.options.SubnetValidationControllerWorkers,
 		ctx.options.Hostname,
-		ctx.metricsNamespace,
-		subnetValidatorMetricsSubsystem,
 	)
 
 	// Start the controller.

--- a/staging/kos/cmd/controller-manager/start_functions.go
+++ b/staging/kos/cmd/controller-manager/start_functions.go
@@ -73,7 +73,7 @@ func startIPAMController(ctx controllerContext, k8sClientCfg, kosClientCfg *rest
 		kosInformers.IPLocks().Informer(),
 		kosInformers.IPLocks().Lister(),
 		eventIfc,
-		workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(200*time.Millisecond, 8*time.Hour), "kos_ipam_controller_queue"),
+		workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(200*time.Millisecond, 8*time.Hour), "ipam"),
 		ctx.options.IPAMControllerWorkers,
 		ctx.options.Hostname,
 	)
@@ -107,7 +107,7 @@ func startSubnetValidationController(ctx controllerContext, k8sClientCfg, kosCli
 		subnets.Informer(),
 		subnets.Lister(),
 		eventIfc,
-		workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(200*time.Millisecond, 8*time.Hour), "kos_subnet_validator_queue"),
+		workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(200*time.Millisecond, 8*time.Hour), "sv"),
 		ctx.options.SubnetValidationControllerWorkers,
 		ctx.options.Hostname,
 	)

--- a/staging/kos/deploy.m4/main/50-d-kcm.yaml.m4
+++ b/staging/kos/deploy.m4/main/50-d-kcm.yaml.m4
@@ -23,9 +23,15 @@ spec:
       - name: kos-controller-manager
         image: DOCKER_PREFIX/kos-controller-manager:latest
         imagePullPolicy: Always
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         command:
         - /controller-manager
         - -v=5
+        - --hostname=$(HOSTNAME)
         - --qps=100
         - --burst=200
         - --indirect-requests=true

--- a/staging/kos/deploy/main/30-role-ca.yaml
+++ b/staging/kos/deploy/main/30-role-ca.yaml
@@ -19,3 +19,4 @@ rules:
   - events
   verbs:
   - create
+  - patch

--- a/staging/kos/deploy/main/30-role-ipam.yaml
+++ b/staging/kos/deploy/main/30-role-ipam.yaml
@@ -24,3 +24,4 @@ rules:
   - events
   verbs:
   - create
+  - patch

--- a/staging/kos/deploy/main/30-role-sv.yaml
+++ b/staging/kos/deploy/main/30-role-sv.yaml
@@ -12,3 +12,10 @@ rules:
   - list
   - watch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/staging/kos/metrics/grafana/dashboard-defs/kos-externals.json
+++ b/staging/kos/metrics/grafana/dashboard-defs/kos-externals.json
@@ -15,9 +15,107 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
   "links": [],
   "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 11,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket{statusErr=\"ok\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "99%ile valid subnets ",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket{statusErr=\"err\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "99%ile conflicting subnets",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket[1m])) by (le))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "99%ile total",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "99th Percentile Subnet Create-to-Validated Latency secs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
     {
       "aliasColors": {},
       "bars": false,
@@ -29,7 +127,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 8
       },
       "id": 2,
       "legend": {
@@ -121,7 +219,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 15
       },
       "id": 1,
       "legend": {
@@ -159,7 +257,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "99th Percentile Create-To-Interface Latency secs",
+      "title": "99th Percentile Create-To-Local-Interface Latency secs",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -207,7 +305,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 22
       },
       "id": 4,
       "legend": {
@@ -244,7 +342,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "99th Percentile Create-to-Ready Latency secs",
+      "title": "99th Percentile Attachment Create-to-Ready Latency secs",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -292,7 +390,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 29
       },
       "id": 9,
       "legend": {
@@ -377,7 +475,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 36
       },
       "id": 8,
       "legend": {
@@ -462,7 +560,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 43
       },
       "id": 7,
       "legend": {
@@ -574,7 +672,7 @@
     ]
   },
   "timezone": "",
-  "title": "KOS External",
+  "title": "KOS Externals",
   "uid": "AlvkAlwik",
   "version": 1
 }

--- a/staging/kos/metrics/grafana/dashboard-defs/kos-externals.json
+++ b/staging/kos/metrics/grafana/dashboard-defs/kos-externals.json
@@ -57,21 +57,22 @@
           "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket{statusErr=\"ok\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "99%ile valid subnets ",
+          "legendFormat": "valid ",
           "refId": "A"
         },
         {
           "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket{statusErr=\"err\"}[1m]))",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
-          "legendFormat": "99%ile conflicting subnets",
+          "legendFormat": "conflicting",
           "refId": "B"
         },
         {
           "expr": "histogram_quantile(0.99, sum(rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket[1m])) by (le))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "99%ile total",
+          "legendFormat": "total",
           "refId": "C"
         }
       ],

--- a/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
+++ b/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
@@ -15,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 7,
   "links": [],
   "panels": [
     {
@@ -142,16 +141,32 @@
         {
           "expr": "kos_agent_worker_count",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ node }}",
+          "legendFormat": "ca @ {{ instance }}",
           "refId": "A"
+        },
+        {
+          "expr": "kos_ipam_worker_count",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "ipam @ {{ instance }}",
+          "refId": "B"
+        },
+        {
+          "expr": "kos_subnet_validator_worker_count ",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "sv @ {{ instance }}",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Number of CA Workers",
+      "title": "Number of Workers",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -201,7 +216,7 @@
         "x": 0,
         "y": 7
       },
-      "id": 2,
+      "id": 54,
       "legend": {
         "avg": false,
         "current": false,
@@ -225,32 +240,27 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_agent_queue_retries[1m])",
+          "expr": "rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m]) / ignoring (mismatch_type) group_left rate(kos_subnet_validator_queue_work_duration_count[1m])",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{ mismatch_type }} mismatch / subnets processed",
           "refId": "A"
         },
         {
-          "expr": "rate(kos_ipam_controller_queue_retries[1m])",
+          "expr": "sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "ipam @ {{ instance }}",
+          "legendFormat": "total mismatches / subnets processed",
           "refId": "B"
-        },
-        {
-          "expr": "rate(kos_subnet_validator_queue_retries[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "snval @ {{ instance }}",
-          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Requeue Rate",
+      "title": "Subnet Validator Conflicts Cache Mismatches to Subnets Processed",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -295,12 +305,12 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
         "y": 14
       },
-      "id": 1,
+      "id": 52,
       "legend": {
         "avg": false,
         "current": false,
@@ -324,32 +334,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_agent_queue_adds[1m])",
+          "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_bucket[1m]))",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
+          "intervalFactor": 1,
+          "legendFormat": "99%ile live list result length",
           "refId": "A"
-        },
-        {
-          "expr": "rate(kos_ipam_controller_queue_adds[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "ipam @ {{ instance }}",
-          "refId": "B"
-        },
-        {
-          "expr": "rate(kos_subnet_validator_queue_adds[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "snval @ {{ instance }}",
-          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Enqueue Rate",
+      "title": "Subnet Validator 99th Percentile Nbr of Subnets in Live Lists results",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -392,14 +388,15 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 23
       },
-      "id": 3,
+      "id": 50,
       "legend": {
         "avg": false,
         "current": false,
@@ -423,32 +420,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_agent_queue_queue_latency_count[1m])",
+          "expr": "rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_sum[1m]) / rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_count[1m])",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
+          "intervalFactor": 1,
+          "legendFormat": "subnet / live list",
           "refId": "A"
-        },
-        {
-          "expr": "rate(kos_ipam_controller_queue_queue_latency_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "ipam @ {{ instance }}",
-          "refId": "B"
-        },
-        {
-          "expr": "rate(kos_subnet_validator_queue_queue_latency_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "snval @ {{ instance }}",
-          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Dequeue Rate",
+      "title": "Subnet Validator Avg Nbr of Subnets in Live Lists Results",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -464,6 +447,7 @@
       },
       "yaxes": [
         {
+          "decimals": 1,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -472,6 +456,7 @@
           "show": true
         },
         {
+          "decimals": null,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -491,14 +476,15 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "Ratio of subnets for whom a status update was not needed because the status was already up-to-date to subnets processed.",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 32
       },
-      "id": 13,
+      "id": 48,
       "legend": {
         "avg": false,
         "current": false,
@@ -522,32 +508,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kos_agent_queue_depth",
+          "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
+          "intervalFactor": 1,
+          "legendFormat": "up to date / processed",
           "refId": "A"
-        },
-        {
-          "expr": "kos_ipam_controller_queue_depth",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "ipam @ {{ instance }}",
-          "refId": "B"
-        },
-        {
-          "expr": "kos_subnet_validator_queue_depth",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "snval @ {{ instance }}",
-          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Queue Length",
+      "title": "Subnet Validator Up to date Subnets to Processed Subnets",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -674,13 +646,1033 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 36,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m])) without (err, statusErr)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "updates @ {{ instance }}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(kos_subnet_validator_live_list_latency_seconds_sum[1m])) without (err)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "lists @ {{ instance }}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Worker Utilization for Calls Out, Summed over Workers",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 34,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "sv @ {{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Worker Utilization, Summed over Workers",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 46,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "stale  / processed",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Stale Subnets Suppressions to Processed Subnets",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_queue_retries[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ca @ {{ instance }}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kos_ipam_controller_queue_retries[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ipam @ {{ instance }}",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_queue_retries[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "sv @ {{ instance }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Requeue Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 79
+      },
+      "id": 1,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_queue_adds[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ca @ {{ instance }}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kos_ipam_controller_queue_adds[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ipam @ {{ instance }}",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_queue_adds[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "sv @ {{ instance }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Enqueue Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_queue_queue_latency_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ca @ {{ instance }}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kos_ipam_controller_queue_queue_latency_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ipam @ {{ instance }}",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_queue_queue_latency_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "sv @ {{ instance }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Dequeue Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 93
+      },
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "kos_agent_queue_depth",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ca @ {{ instance }}",
+          "refId": "A"
+        },
+        {
+          "expr": "kos_ipam_controller_queue_depth",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ipam @ {{ instance }}",
+          "refId": "B"
+        },
+        {
+          "expr": "kos_subnet_validator_queue_depth",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "sv @ {{ instance }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Queue Length",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 100
+      },
+      "id": 40,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_update_latency_seconds_bucket[1m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}  status update {{ statusErr }} {{ err }}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_live_list_latency_seconds_bucket[1m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} live list {{ err }}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "99th Percentile Subnet Validator Call Out Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 109
+      },
+      "id": 38,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_subnet_update_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} status update subnet={{ statusErr }} result={{ err }}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_live_list_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} live list {{ err }}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Rate of Subnet Validator Call Outs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "When validating a subnet X, the Subnet Validator uses live lists to retrieve potentially conflicting subnets. Sometimes X's status is already up to date hence all processing including the live list was useless. This graph plots the ratio between useless live lists to the total of live lists.",
+      "fill": 1,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 118
+      },
+      "id": 44,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) + sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / ignoring (err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "useless / total successful @ {{ instance }} ",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Useless Live Lists to Live Lists",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 128
+      },
+      "id": 42,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m]) / rate(kos_subnet_validator_subnet_update_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} status update {{ statusErr }} {{ err }}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_live_list_latency_seconds_sum[1m]) / rate(kos_subnet_validator_live_list_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} live list {{ err }}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Subnet Validator Call Out Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
       "description": "Sum, over workers, of utilization of that worker",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 137
       },
       "id": 25,
       "legend": {
@@ -765,7 +1757,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 144
       },
       "id": 27,
       "legend": {
@@ -857,7 +1849,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 151
       },
       "id": 28,
       "legend": {
@@ -949,7 +1941,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 158
       },
       "id": 30,
       "legend": {
@@ -1041,7 +2033,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 69
+        "y": 165
       },
       "id": 32,
       "legend": {
@@ -1133,7 +2125,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 172
       },
       "id": 4,
       "legend": {
@@ -1218,7 +2210,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 83
+        "y": 179
       },
       "id": 29,
       "legend": {
@@ -1303,7 +2295,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 90
+        "y": 186
       },
       "id": 31,
       "legend": {
@@ -1388,7 +2380,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 97
+        "y": 193
       },
       "id": 5,
       "legend": {
@@ -1473,7 +2465,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 200
       },
       "id": 6,
       "legend": {
@@ -1558,7 +2550,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 111
+        "y": 207
       },
       "id": 12,
       "legend": {
@@ -1643,7 +2635,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 118
+        "y": 214
       },
       "id": 14,
       "legend": {
@@ -1728,7 +2720,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 125
+        "y": 221
       },
       "id": 15,
       "legend": {
@@ -1813,7 +2805,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 132
+        "y": 228
       },
       "id": 16,
       "legend": {
@@ -1898,7 +2890,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 139
+        "y": 235
       },
       "id": 17,
       "legend": {
@@ -1983,7 +2975,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 146
+        "y": 242
       },
       "id": 7,
       "legend": {
@@ -2082,7 +3074,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 153
+        "y": 249
       },
       "id": 18,
       "legend": {
@@ -2167,7 +3159,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 160
+        "y": 256
       },
       "id": 19,
       "legend": {

--- a/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
+++ b/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
@@ -26,93 +26,8 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 0
-      },
-      "id": 21,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(kos_agent_fabric_count) by (fabric)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ fabric }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Number of CA, By Fabric Name",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
         "y": 0
       },
       "id": 23,
@@ -211,808 +126,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
-        "w": 24,
+        "h": 8,
+        "w": 12,
         "x": 0,
         "y": 7
-      },
-      "id": 54,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m]) / ignoring (mismatch_type) group_left rate(kos_subnet_validator_queue_work_duration_count[1m])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "{{ mismatch_type }} mismatch / subnets processed",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "total mismatches / subnets processed",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Conflicts Cache Mismatches to Subnets Processed",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 14
-      },
-      "id": 52,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_bucket[1m]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "99%ile live list result length",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator 99th Percentile Nbr of Subnets in Live Lists results",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "description": "",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 23
-      },
-      "id": 50,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_sum[1m]) / rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "subnet / live list",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Avg Nbr of Subnets in Live Lists Results",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 1,
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "decimals": null,
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "description": "Ratio of subnets for whom a status update was not needed because the status was already up-to-date to subnets processed.",
-      "fill": 1,
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 32
-      },
-      "id": 48,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "up to date / processed",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Up to date Subnets to Processed Subnets",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "fill": 1,
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 35
-      },
-      "id": 34,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Worker Utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 48
-      },
-      "id": 36,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m])) without (err, statusErr)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "updates @ {{ instance }}",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(rate(kos_subnet_validator_live_list_latency_seconds_sum[1m])) without (err)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "lists @ {{ instance }}",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Worker Utilization for Calls Out, Summed over Workers",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 57
-      },
-      "id": 34,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "sv @ {{ instance }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Worker Utilization, Summed over Workers",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 63
-      },
-      "id": 46,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "stale  / processed",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Stale Subnets Suppressions to Processed Subnets",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 72
-      },
-      "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_agent_queue_retries[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
-          "refId": "A"
-        },
-        {
-          "expr": "rate(kos_ipam_controller_queue_retries[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ipam @ {{ instance }}",
-          "refId": "B"
-        },
-        {
-          "expr": "rate(kos_subnet_validator_queue_retries[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "sv @ {{ instance }}",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Requeue Rate",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 79
       },
       "id": 1,
       "legend": {
@@ -1108,10 +225,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 86
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
       },
       "id": 3,
       "legend": {
@@ -1207,10 +324,109 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
-        "w": 24,
+        "h": 8,
+        "w": 12,
         "x": 0,
-        "y": 93
+        "y": 15
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_queue_retries[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ca @ {{ instance }}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kos_ipam_controller_queue_retries[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "ipam @ {{ instance }}",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_queue_retries[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "sv @ {{ instance }}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Requeue Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
       },
       "id": 13,
       "legend": {
@@ -1309,7 +525,185 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 100
+        "y": 23
+      },
+      "id": 56,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Worker Utilization, Summed over Workers",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 36,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m])) without (err, statusErr)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "updates @ {{ instance }}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(kos_subnet_validator_live_list_latency_seconds_sum[1m])) without (err)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "lists @ {{ instance }}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Worker Utilization for Calls Out, Summed over Workers",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 41
       },
       "id": 40,
       "legend": {
@@ -1401,185 +795,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 109
-      },
-      "id": 38,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_subnet_validator_subnet_update_latency_seconds_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }} status update subnet={{ statusErr }} result={{ err }}",
-          "refId": "A"
-        },
-        {
-          "expr": "rate(kos_subnet_validator_live_list_latency_seconds_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }} live list {{ err }}",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Rate of Subnet Validator Call Outs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "description": "When validating a subnet X, the Subnet Validator uses live lists to retrieve potentially conflicting subnets. Sometimes X's status is already up to date hence all processing including the live list was useless. This graph plots the ratio between useless live lists to the total of live lists.",
-      "fill": 1,
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 118
-      },
-      "id": 44,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) + sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / ignoring (err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "useless / total successful @ {{ instance }} ",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Useless Live Lists to Live Lists",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 128
+        "y": 52
       },
       "id": 42,
       "legend": {
@@ -1666,13 +882,470 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "id": 38,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_subnet_update_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} status update {{ statusErr }} {{ err }}",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_live_list_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} live list {{ err }}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Rate of Subnet Validator Call Outs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "When validating a subnet X, the Subnet Validator uses live lists to retrieve potentially conflicting subnets. Sometimes X's status is already up to date hence all processing including the live list was useless. This graph plots the ratio between useless live lists to the total of live lists.",
+      "fill": 1,
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 44,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(rate(kos_subnet_validator_duplicate_work_count[1m]) + sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type)) / ignoring (err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m]) / ignoring (mismatch_type, err) group_left rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ mismatch_type }} mismatch",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / ignoring(err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total cache mismatches",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) / ignoring(err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "subnet status up to date",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Fraction of Live Lists not Needed",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 80
+      },
+      "id": 46,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "stale  / processed",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Fraction of Subnet Syncs Ended By Stale Cache",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 89
+      },
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_bucket[1m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator 99th Percentile Nbr of Subnets in Live Lists results",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 98
+      },
+      "id": 50,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_sum[1m]) / rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Subnet Validator Avg Nbr of Subnets in Live Lists Results",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 1,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
       "description": "Sum, over workers, of utilization of that worker",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 137
+        "y": 107
       },
       "id": 25,
       "legend": {
@@ -1757,7 +1430,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 144
+        "y": 114
       },
       "id": 27,
       "legend": {
@@ -1849,7 +1522,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 151
+        "y": 121
       },
       "id": 28,
       "legend": {
@@ -1941,99 +1614,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 158
-      },
-      "id": 30,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_ipam_attachment_update_latency_seconds_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }} status update {{ statusErr }} {{ err }}",
-          "refId": "A"
-        },
-        {
-          "expr": "rate(kos_ipam_ip_lock_latency_seconds_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ instance }} lock {{ op }} {{ err }}",
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Rate of IPAM Call Outs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 165
+        "y": 128
       },
       "id": 32,
       "legend": {
@@ -2125,9 +1706,9 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 172
+        "y": 135
       },
-      "id": 4,
+      "id": 30,
       "legend": {
         "avg": false,
         "current": false,
@@ -2151,18 +1732,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_agent_queue_work_duration_sum[1m])/1.0e6",
+          "expr": "rate(kos_ipam_attachment_update_latency_seconds_count[1m])",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} status update {{ statusErr }} {{ err }}",
           "refId": "A"
+        },
+        {
+          "expr": "rate(kos_ipam_ip_lock_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ instance }} lock {{ op }} {{ err }}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Connection Agent Worker Utilization, summed over workers",
+      "title": "Rate of IPAM Call Outs",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2210,772 +1798,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 179
-      },
-      "id": 29,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.99, rate(kos_agent_attachment_status_latency_seconds_bucket[1m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "99th Percentile Status Update From CA Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 186
-      },
-      "id": 31,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_agent_attachment_status_latency_seconds_sum[1m]) / rate(kos_agent_attachment_status_latency_seconds_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Average Status Update From CA Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 193
-      },
-      "id": 5,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(rate(kos_agent_fabric_latency_seconds_sum[1m])) by (node)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Network Fabric utilization, summed over workers",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 200
-      },
-      "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.99, rate(kos_agent_fabric_latency_seconds_bucket{op=~\"Create.*Ifc\",err!=\"true\"}[1m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ op }}@{{ node }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "99th Percentile Successful Fabric Create*Port Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 207
-      },
-      "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.90, rate(kos_agent_fabric_latency_seconds_bucket{op=~\"Create.*Ifc\"}[1m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ op }}@{{ node }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "90th Percentile Fabric Create*Port Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 214
-      },
-      "id": 14,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"CreateLocalIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"CreateLocalIfc\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Average CreateLocalPort Secs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 221
-      },
-      "id": 15,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"CreateRemoteIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"CreateRemoteIfc\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Average CreateRemotePort secs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 228
-      },
-      "id": 16,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"DeleteLocalIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"DeleteLocalIfc\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Average DeleteLocalPort Secs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 235
-      },
-      "id": 17,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"DeleteRemoteIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"DeleteRemoteIfc\"}[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Average DeleteRemotePort Secs",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 242
+        "y": 142
       },
       "id": 7,
       "legend": {
@@ -3074,7 +1897,942 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 249
+        "y": 149
+      },
+      "id": 21,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(kos_agent_fabric_count) by (fabric)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ fabric }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Number of CA, By Fabric Name",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 156
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_queue_work_duration_sum[1m])/1.0e6",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ instance }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Connection Agent Worker Utilization, summed over workers",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 163
+      },
+      "id": 29,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, rate(kos_agent_attachment_status_latency_seconds_bucket[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "99th Percentile Status Update From CA Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 170
+      },
+      "id": 31,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_attachment_status_latency_seconds_sum[1m]) / rate(kos_agent_attachment_status_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Status Update From CA Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 177
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(kos_agent_fabric_latency_seconds_sum[1m])) by (node)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network Fabric utilization, summed over workers",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 184
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, rate(kos_agent_fabric_latency_seconds_bucket{op=~\"Create.*Ifc\",err!=\"true\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ op }}@{{ node }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "99th Percentile Successful Fabric Create*Port Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 191
+      },
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.90, rate(kos_agent_fabric_latency_seconds_bucket{op=~\"Create.*Ifc\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ op }}@{{ node }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "90th Percentile Fabric Create*Port Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 198
+      },
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"CreateLocalIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"CreateLocalIfc\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average CreateLocalPort Secs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 205
+      },
+      "id": 15,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"CreateRemoteIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"CreateRemoteIfc\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average CreateRemotePort secs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 212
+      },
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"DeleteLocalIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"DeleteLocalIfc\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average DeleteLocalPort Secs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 219
+      },
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"DeleteRemoteIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"DeleteRemoteIfc\"}[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average DeleteRemotePort Secs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 226
       },
       "id": 18,
       "legend": {
@@ -3159,7 +2917,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 256
+        "y": 233
       },
       "id": 19,
       "legend": {

--- a/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
+++ b/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
@@ -155,25 +155,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_agent_queue_adds[1m])",
+          "expr": "rate(kos_workqueue_adds_total[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
+          "legendFormat": "{{ name }} @ {{ instance }}",
           "refId": "A"
-        },
-        {
-          "expr": "rate(kos_ipam_controller_queue_adds[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ipam @ {{ instance }}",
-          "refId": "B"
-        },
-        {
-          "expr": "rate(kos_subnet_validator_queue_adds[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "sv @ {{ instance }}",
-          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -254,25 +240,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_agent_queue_queue_latency_count[1m])",
+          "expr": "rate(kos_workqueue_queue_duration_seconds_count[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
+          "legendFormat": "{{ name }} @ {{ instance }}",
           "refId": "A"
-        },
-        {
-          "expr": "rate(kos_ipam_controller_queue_queue_latency_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ipam @ {{ instance }}",
-          "refId": "B"
-        },
-        {
-          "expr": "rate(kos_subnet_validator_queue_queue_latency_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "sv @ {{ instance }}",
-          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -353,25 +325,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_agent_queue_retries[1m])",
+          "expr": "rate(kos_workqueue_retries_total[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
+          "legendFormat": "{{ name }} @ {{ instance }}",
           "refId": "A"
-        },
-        {
-          "expr": "rate(kos_ipam_controller_queue_retries[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ipam @ {{ instance }}",
-          "refId": "B"
-        },
-        {
-          "expr": "rate(kos_subnet_validator_queue_retries[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "sv @ {{ instance }}",
-          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -452,25 +410,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kos_agent_queue_depth",
+          "expr": "kos_workqueue_depth",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "ca @ {{ instance }}",
+          "legendFormat": "{{ name }} @ {{ instance }}",
           "refId": "A"
-        },
-        {
-          "expr": "kos_ipam_controller_queue_depth",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "ipam @ {{ instance }}",
-          "refId": "B"
-        },
-        {
-          "expr": "kos_subnet_validator_queue_depth",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "sv @ {{ instance }}",
-          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -520,6 +464,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "Sum, over workers, of utilization of that worker",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -551,11 +496,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
+          "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"sv\"}[1m])",
           "format": "time_series",
-          "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
+          "legendFormat": "{{ instance  }}",
           "refId": "A"
         }
       ],
@@ -563,7 +507,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Subnet Validator Worker Utilization, Summed over Workers",
+      "title": "Subnet Validator Worker Utilization",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -606,6 +550,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "Sum, over workers, of utilization of that worker spent on calls out.",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -655,7 +600,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Subnet Validator Worker Utilization for Calls Out, Summed over Workers",
+      "title": "Subnet Validator Worker Utilization for Calls Out",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1112,7 +1057,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
+          "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / ignoring (name) rate(kos_workqueue_work_duration_seconds_count{name=\"sv\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "stale  / processed",
@@ -1342,7 +1287,7 @@
       "description": "Sum, over workers, of utilization of that worker",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 107
@@ -1371,7 +1316,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_ipam_controller_queue_work_duration_sum[1m])/1.0e6",
+          "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"ipam\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ instance }}",
@@ -1425,12 +1370,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "Sum, over workers, of utilization of that worker spent on calls out.",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 114
+        "y": 115
       },
       "id": 27,
       "legend": {
@@ -1522,7 +1468,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 121
+        "y": 122
       },
       "id": 28,
       "legend": {
@@ -1614,7 +1560,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 128
+        "y": 129
       },
       "id": 32,
       "legend": {
@@ -1706,7 +1652,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 135
+        "y": 136
       },
       "id": 30,
       "legend": {
@@ -1798,7 +1744,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 142
+        "y": 143
       },
       "id": 7,
       "legend": {
@@ -1897,7 +1843,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 149
+        "y": 150
       },
       "id": 21,
       "legend": {
@@ -1977,12 +1923,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "Sum, over workers, of utilization of that worker",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 156
+        "y": 157
       },
       "id": 4,
       "legend": {
@@ -2008,7 +1955,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(kos_agent_queue_work_duration_sum[1m])/1.0e6",
+          "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"ca\"}[1m])",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance }}",
@@ -2019,7 +1966,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Connection Agent Worker Utilization, summed over workers",
+      "title": "Connection Agent Worker Utilization",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2067,177 +2014,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 163
-      },
-      "id": 29,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.99, rate(kos_agent_attachment_status_latency_seconds_bucket[1m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "99th Percentile Status Update From CA Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 170
-      },
-      "id": 31,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(kos_agent_attachment_status_latency_seconds_sum[1m]) / rate(kos_agent_attachment_status_latency_seconds_count[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Average Status Update From CA Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 177
+        "y": 164
       },
       "id": 5,
       "legend": {
@@ -2322,7 +2099,177 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 184
+        "y": 171
+      },
+      "id": 29,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, rate(kos_agent_attachment_status_latency_seconds_bucket[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "99th Percentile Status Update From CA Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 178
+      },
+      "id": 31,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(kos_agent_attachment_status_latency_seconds_sum[1m]) / rate(kos_agent_attachment_status_latency_seconds_count[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Status Update From CA Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 185
       },
       "id": 6,
       "legend": {
@@ -2407,7 +2354,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 191
+        "y": 192
       },
       "id": 12,
       "legend": {
@@ -2492,7 +2439,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 198
+        "y": 199
       },
       "id": 14,
       "legend": {
@@ -2577,7 +2524,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 205
+        "y": 206
       },
       "id": 15,
       "legend": {
@@ -2662,7 +2609,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 212
+        "y": 213
       },
       "id": 16,
       "legend": {
@@ -2747,7 +2694,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 219
+        "y": 220
       },
       "id": 17,
       "legend": {
@@ -2832,7 +2779,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 226
+        "y": 227
       },
       "id": 18,
       "legend": {
@@ -2917,7 +2864,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 233
+        "y": 234
       },
       "id": 19,
       "legend": {

--- a/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
+++ b/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
@@ -5203,25 +5203,11 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_agent_queue_adds[1m])",
+              "expr": "rate(kos_workqueue_adds_total[1m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
+              "legendFormat": "{{ name }} @ {{ instance }}",
               "refId": "A"
-            },
-            {
-              "expr": "rate(kos_ipam_controller_queue_adds[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ipam @ {{ instance }}",
-              "refId": "B"
-            },
-            {
-              "expr": "rate(kos_subnet_validator_queue_adds[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "sv @ {{ instance }}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -5302,25 +5288,11 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_agent_queue_queue_latency_count[1m])",
+              "expr": "rate(kos_workqueue_queue_duration_seconds_count[1m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
+              "legendFormat": "{{ name }} @ {{ instance }}",
               "refId": "A"
-            },
-            {
-              "expr": "rate(kos_ipam_controller_queue_queue_latency_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ipam @ {{ instance }}",
-              "refId": "B"
-            },
-            {
-              "expr": "rate(kos_subnet_validator_queue_queue_latency_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "sv @ {{ instance }}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -5401,25 +5373,11 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_agent_queue_retries[1m])",
+              "expr": "rate(kos_workqueue_retries_total[1m])",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
+              "legendFormat": "{{ name }} @ {{ instance }}",
               "refId": "A"
-            },
-            {
-              "expr": "rate(kos_ipam_controller_queue_retries[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ipam @ {{ instance }}",
-              "refId": "B"
-            },
-            {
-              "expr": "rate(kos_subnet_validator_queue_retries[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "sv @ {{ instance }}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -5500,25 +5458,11 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "kos_agent_queue_depth",
+              "expr": "kos_workqueue_depth",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
+              "legendFormat": "{{ name }} @ {{ instance }}",
               "refId": "A"
-            },
-            {
-              "expr": "kos_ipam_controller_queue_depth",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ipam @ {{ instance }}",
-              "refId": "B"
-            },
-            {
-              "expr": "kos_subnet_validator_queue_depth",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "sv @ {{ instance }}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
@@ -5568,6 +5512,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "Sum, over workers, of utilization of that worker",
           "fill": 1,
           "gridPos": {
             "h": 9,
@@ -5599,11 +5544,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
+              "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"sv\"}[1m])",
               "format": "time_series",
-              "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{ instance }}",
+              "legendFormat": "{{ instance  }}",
               "refId": "A"
             }
           ],
@@ -5611,7 +5555,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Subnet Validator Worker Utilization, Summed over Workers",
+          "title": "Subnet Validator Worker Utilization",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5654,6 +5598,7 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "Sum, over workers, of utilization of that worker spent on calls out.",
           "fill": 1,
           "gridPos": {
             "h": 9,
@@ -5703,7 +5648,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Subnet Validator Worker Utilization for Calls Out, Summed over Workers",
+          "title": "Subnet Validator Worker Utilization for Calls Out",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -6160,7 +6105,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
+              "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / ignoring (name) rate(kos_workqueue_work_duration_seconds_count{name=\"sv\"}[1m])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "stale  / processed",
@@ -6390,7 +6335,7 @@ data:
           "description": "Sum, over workers, of utilization of that worker",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 24,
             "x": 0,
             "y": 107
@@ -6419,7 +6364,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_ipam_controller_queue_work_duration_sum[1m])/1.0e6",
+              "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"ipam\"}[1m])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{ instance }}",
@@ -6473,12 +6418,13 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "Sum, over workers, of utilization of that worker spent on calls out.",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 114
+            "y": 115
           },
           "id": 27,
           "legend": {
@@ -6570,7 +6516,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 121
+            "y": 122
           },
           "id": 28,
           "legend": {
@@ -6662,7 +6608,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 128
+            "y": 129
           },
           "id": 32,
           "legend": {
@@ -6754,7 +6700,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 135
+            "y": 136
           },
           "id": 30,
           "legend": {
@@ -6846,7 +6792,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 142
+            "y": 143
           },
           "id": 7,
           "legend": {
@@ -6945,7 +6891,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 149
+            "y": 150
           },
           "id": 21,
           "legend": {
@@ -7025,12 +6971,13 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "Sum, over workers, of utilization of that worker",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 156
+            "y": 157
           },
           "id": 4,
           "legend": {
@@ -7056,7 +7003,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_agent_queue_work_duration_sum[1m])/1.0e6",
+              "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"ca\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ instance }}",
@@ -7067,7 +7014,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Connection Agent Worker Utilization, summed over workers",
+          "title": "Connection Agent Worker Utilization",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -7115,177 +7062,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 163
-          },
-          "id": 29,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.99, rate(kos_agent_attachment_status_latency_seconds_bucket[1m]))",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "99th Percentile Status Update From CA Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 170
-          },
-          "id": 31,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_agent_attachment_status_latency_seconds_sum[1m]) / rate(kos_agent_attachment_status_latency_seconds_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Average Status Update From CA Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 177
+            "y": 164
           },
           "id": 5,
           "legend": {
@@ -7370,7 +7147,177 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 184
+            "y": 171
+          },
+          "id": 29,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, rate(kos_agent_attachment_status_latency_seconds_bucket[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "99th Percentile Status Update From CA Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 178
+          },
+          "id": 31,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_attachment_status_latency_seconds_sum[1m]) / rate(kos_agent_attachment_status_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average Status Update From CA Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 185
           },
           "id": 6,
           "legend": {
@@ -7455,7 +7402,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 191
+            "y": 192
           },
           "id": 12,
           "legend": {
@@ -7540,7 +7487,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 198
+            "y": 199
           },
           "id": 14,
           "legend": {
@@ -7625,7 +7572,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 205
+            "y": 206
           },
           "id": 15,
           "legend": {
@@ -7710,7 +7657,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 212
+            "y": 213
           },
           "id": 16,
           "legend": {
@@ -7795,7 +7742,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 219
+            "y": 220
           },
           "id": 17,
           "legend": {
@@ -7880,7 +7827,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 226
+            "y": 227
           },
           "id": 18,
           "legend": {
@@ -7965,7 +7912,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 233
+            "y": 234
           },
           "id": 19,
           "legend": {

--- a/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
+++ b/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
@@ -4425,21 +4425,22 @@ data:
               "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket{statusErr=\"ok\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "99%ile valid subnets ",
+              "legendFormat": "valid ",
               "refId": "A"
             },
             {
               "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket{statusErr=\"err\"}[1m]))",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "99%ile conflicting subnets",
+              "legendFormat": "conflicting",
               "refId": "B"
             },
             {
               "expr": "histogram_quantile(0.99, sum(rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket[1m])) by (le))",
               "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "99%ile total",
+              "legendFormat": "total",
               "refId": "C"
             }
           ],
@@ -5073,93 +5074,8 @@ data:
           "fill": 1,
           "gridPos": {
             "h": 7,
-            "w": 12,
+            "w": 24,
             "x": 0,
-            "y": 0
-          },
-          "id": 21,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(kos_agent_fabric_count) by (fabric)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{ fabric }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Number of CA, By Fabric Name",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
             "y": 0
           },
           "id": 23,
@@ -5258,808 +5174,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
-            "w": 24,
+            "h": 8,
+            "w": 12,
             "x": 0,
             "y": 7
-          },
-          "id": 54,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m]) / ignoring (mismatch_type) group_left rate(kos_subnet_validator_queue_work_duration_count[1m])",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": "{{ mismatch_type }} mismatch / subnets processed",
-              "refId": "A"
-            },
-            {
-              "expr": "sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 1,
-              "legendFormat": "total mismatches / subnets processed",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Conflicts Cache Mismatches to Subnets Processed",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 14
-          },
-          "id": 52,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_bucket[1m]))",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "99%ile live list result length",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator 99th Percentile Nbr of Subnets in Live Lists results",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "description": "",
-          "fill": 1,
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 23
-          },
-          "id": 50,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_sum[1m]) / rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "subnet / live list",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Avg Nbr of Subnets in Live Lists Results",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "decimals": 1,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "decimals": null,
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "description": "Ratio of subnets for whom a status update was not needed because the status was already up-to-date to subnets processed.",
-          "fill": 1,
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 32
-          },
-          "id": 48,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "up to date / processed",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Up to date Subnets to Processed Subnets",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "fill": 1,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 35
-          },
-          "id": 34,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{ instance }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Worker Utilization",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 48
-          },
-          "id": 36,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m])) without (err, statusErr)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "updates @ {{ instance }}",
-              "refId": "A"
-            },
-            {
-              "expr": "sum(rate(kos_subnet_validator_live_list_latency_seconds_sum[1m])) without (err)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "lists @ {{ instance }}",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Worker Utilization for Calls Out, Summed over Workers",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 6,
-            "w": 24,
-            "x": 0,
-            "y": 57
-          },
-          "id": 34,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "sv @ {{ instance }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Worker Utilization, Summed over Workers",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 63
-          },
-          "id": 46,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "stale  / processed",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Stale Subnets Suppressions to Processed Subnets",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 72
-          },
-          "id": 2,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_agent_queue_retries[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
-              "refId": "A"
-            },
-            {
-              "expr": "rate(kos_ipam_controller_queue_retries[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ipam @ {{ instance }}",
-              "refId": "B"
-            },
-            {
-              "expr": "rate(kos_subnet_validator_queue_retries[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "sv @ {{ instance }}",
-              "refId": "C"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Requeue Rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 79
           },
           "id": 1,
           "legend": {
@@ -6155,10 +5273,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 86
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7
           },
           "id": 3,
           "legend": {
@@ -6254,10 +5372,109 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
-            "w": 24,
+            "h": 8,
+            "w": 12,
             "x": 0,
-            "y": 93
+            "y": 15
+          },
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_queue_retries[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ca @ {{ instance }}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(kos_ipam_controller_queue_retries[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ipam @ {{ instance }}",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_queue_retries[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "sv @ {{ instance }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Requeue Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
           },
           "id": 13,
           "legend": {
@@ -6356,7 +5573,185 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 100
+            "y": 23
+          },
+          "id": 56,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Worker Utilization, Summed over Workers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
+          "id": 36,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m])) without (err, statusErr)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "updates @ {{ instance }}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(kos_subnet_validator_live_list_latency_seconds_sum[1m])) without (err)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "lists @ {{ instance }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Worker Utilization for Calls Out, Summed over Workers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 11,
+            "w": 24,
+            "x": 0,
+            "y": 41
           },
           "id": 40,
           "legend": {
@@ -6448,185 +5843,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 109
-          },
-          "id": 38,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_subnet_validator_subnet_update_latency_seconds_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{ instance }} status update subnet={{ statusErr }} result={{ err }}",
-              "refId": "A"
-            },
-            {
-              "expr": "rate(kos_subnet_validator_live_list_latency_seconds_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{ instance }} live list {{ err }}",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Rate of Subnet Validator Call Outs",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "description": "When validating a subnet X, the Subnet Validator uses live lists to retrieve potentially conflicting subnets. Sometimes X's status is already up to date hence all processing including the live list was useless. This graph plots the ratio between useless live lists to the total of live lists.",
-          "fill": 1,
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 118
-          },
-          "id": 44,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) + sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / ignoring (err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "useless / total successful @ {{ instance }} ",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Useless Live Lists to Live Lists",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 128
+            "y": 52
           },
           "id": 42,
           "legend": {
@@ -6713,13 +5930,470 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 61
+          },
+          "id": 38,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_subnet_update_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} status update {{ statusErr }} {{ err }}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_live_list_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} live list {{ err }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Rate of Subnet Validator Call Outs",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "description": "When validating a subnet X, the Subnet Validator uses live lists to retrieve potentially conflicting subnets. Sometimes X's status is already up to date hence all processing including the live list was useless. This graph plots the ratio between useless live lists to the total of live lists.",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 70
+          },
+          "id": 44,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(rate(kos_subnet_validator_duplicate_work_count[1m]) + sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type)) / ignoring (err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "total",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m]) / ignoring (mismatch_type, err) group_left rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ mismatch_type }} mismatch",
+              "refId": "B"
+            },
+            {
+              "expr": "sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / ignoring(err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "total cache mismatches",
+              "refId": "C"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) / ignoring(err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "subnet status up to date",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Fraction of Live Lists not Needed",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 80
+          },
+          "id": 46,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "stale  / processed",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Fraction of Subnet Syncs Ended By Stale Cache",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 89
+          },
+          "id": 52,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_bucket[1m]))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator 99th Percentile Nbr of Subnets in Live Lists results",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "description": "",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 98
+          },
+          "id": 50,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_sum[1m]) / rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Avg Nbr of Subnets in Live Lists Results",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 1,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
           "description": "Sum, over workers, of utilization of that worker",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 137
+            "y": 107
           },
           "id": 25,
           "legend": {
@@ -6804,7 +6478,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 144
+            "y": 114
           },
           "id": 27,
           "legend": {
@@ -6896,7 +6570,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 151
+            "y": 121
           },
           "id": 28,
           "legend": {
@@ -6988,99 +6662,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 158
-          },
-          "id": 30,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_ipam_attachment_update_latency_seconds_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{ instance }} status update {{ statusErr }} {{ err }}",
-              "refId": "A"
-            },
-            {
-              "expr": "rate(kos_ipam_ip_lock_latency_seconds_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{ instance }} lock {{ op }} {{ err }}",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Rate of IPAM Call Outs",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 165
+            "y": 128
           },
           "id": 32,
           "legend": {
@@ -7172,9 +6754,9 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 172
+            "y": 135
           },
-          "id": 4,
+          "id": 30,
           "legend": {
             "avg": false,
             "current": false,
@@ -7198,18 +6780,25 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_agent_queue_work_duration_sum[1m])/1.0e6",
+              "expr": "rate(kos_ipam_attachment_update_latency_seconds_count[1m])",
               "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ instance }}",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} status update {{ statusErr }} {{ err }}",
               "refId": "A"
+            },
+            {
+              "expr": "rate(kos_ipam_ip_lock_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} lock {{ op }} {{ err }}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Connection Agent Worker Utilization, summed over workers",
+          "title": "Rate of IPAM Call Outs",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -7257,772 +6846,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 179
-          },
-          "id": 29,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.99, rate(kos_agent_attachment_status_latency_seconds_bucket[1m]))",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "99th Percentile Status Update From CA Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 186
-          },
-          "id": 31,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_agent_attachment_status_latency_seconds_sum[1m]) / rate(kos_agent_attachment_status_latency_seconds_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Average Status Update From CA Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 193
-          },
-          "id": 5,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(kos_agent_fabric_latency_seconds_sum[1m])) by (node)",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Network Fabric utilization, summed over workers",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 200
-          },
-          "id": 6,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.99, rate(kos_agent_fabric_latency_seconds_bucket{op=~\"Create.*Ifc\",err!=\"true\"}[1m]))",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ op }}@{{ node }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "99th Percentile Successful Fabric Create*Port Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 207
-          },
-          "id": 12,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.90, rate(kos_agent_fabric_latency_seconds_bucket{op=~\"Create.*Ifc\"}[1m]))",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ op }}@{{ node }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "90th Percentile Fabric Create*Port Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 214
-          },
-          "id": 14,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"CreateLocalIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"CreateLocalIfc\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Average CreateLocalPort Secs",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 221
-          },
-          "id": 15,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"CreateRemoteIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"CreateRemoteIfc\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Average CreateRemotePort secs",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 228
-          },
-          "id": 16,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"DeleteLocalIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"DeleteLocalIfc\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Average DeleteLocalPort Secs",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 235
-          },
-          "id": 17,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"DeleteRemoteIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"DeleteRemoteIfc\"}[1m])",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{ node }} {{ err }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Average DeleteRemotePort Secs",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 242
+            "y": 142
           },
           "id": 7,
           "legend": {
@@ -8121,7 +6945,942 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 249
+            "y": 149
+          },
+          "id": 21,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(kos_agent_fabric_count) by (fabric)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ fabric }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of CA, By Fabric Name",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 156
+          },
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_queue_work_duration_sum[1m])/1.0e6",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ instance }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Connection Agent Worker Utilization, summed over workers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 163
+          },
+          "id": 29,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, rate(kos_agent_attachment_status_latency_seconds_bucket[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "99th Percentile Status Update From CA Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 170
+          },
+          "id": 31,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_attachment_status_latency_seconds_sum[1m]) / rate(kos_agent_attachment_status_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }} {{ statusErr }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average Status Update From CA Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 177
+          },
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(kos_agent_fabric_latency_seconds_sum[1m])) by (node)",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Network Fabric utilization, summed over workers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 184
+          },
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, rate(kos_agent_fabric_latency_seconds_bucket{op=~\"Create.*Ifc\",err!=\"true\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ op }}@{{ node }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "99th Percentile Successful Fabric Create*Port Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 191
+          },
+          "id": 12,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.90, rate(kos_agent_fabric_latency_seconds_bucket{op=~\"Create.*Ifc\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ op }}@{{ node }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "90th Percentile Fabric Create*Port Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 198
+          },
+          "id": 14,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"CreateLocalIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"CreateLocalIfc\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average CreateLocalPort Secs",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 205
+          },
+          "id": 15,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"CreateRemoteIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"CreateRemoteIfc\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average CreateRemotePort secs",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 212
+          },
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"DeleteLocalIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"DeleteLocalIfc\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average DeleteLocalPort Secs",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 219
+          },
+          "id": 17,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_fabric_latency_seconds_sum{op=\"DeleteRemoteIfc\"}[1m])/rate(kos_agent_fabric_latency_seconds_count{op=\"DeleteRemoteIfc\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{ node }} {{ err }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average DeleteRemotePort Secs",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 226
           },
           "id": 18,
           "legend": {
@@ -8206,7 +7965,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 256
+            "y": 233
           },
           "id": 19,
           "legend": {

--- a/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
+++ b/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
@@ -4383,9 +4383,107 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 3,
       "links": [],
       "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 11,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket{statusErr=\"ok\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99%ile valid subnets ",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket{statusErr=\"err\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99%ile conflicting subnets",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(kos_subnet_validator_subnet_create_to_validated_latency_seconds_bucket[1m])) by (le))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "99%ile total",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "99th Percentile Subnet Create-to-Validated Latency secs",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
         {
           "aliasColors": {},
           "bars": false,
@@ -4397,7 +4495,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 0
+            "y": 8
           },
           "id": 2,
           "legend": {
@@ -4489,7 +4587,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 7
+            "y": 15
           },
           "id": 1,
           "legend": {
@@ -4527,7 +4625,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "99th Percentile Create-To-Interface Latency secs",
+          "title": "99th Percentile Create-To-Local-Interface Latency secs",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -4575,7 +4673,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 14
+            "y": 22
           },
           "id": 4,
           "legend": {
@@ -4612,7 +4710,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "99th Percentile Create-to-Ready Latency secs",
+          "title": "99th Percentile Attachment Create-to-Ready Latency secs",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -4660,7 +4758,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 21
+            "y": 29
           },
           "id": 9,
           "legend": {
@@ -4745,7 +4843,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 28
+            "y": 36
           },
           "id": 8,
           "legend": {
@@ -4830,7 +4928,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 43
           },
           "id": 7,
           "legend": {
@@ -4942,7 +5040,7 @@ data:
         ]
       },
       "timezone": "",
-      "title": "KOS External",
+      "title": "KOS Externals",
       "uid": "AlvkAlwik",
       "version": 1
     }
@@ -4964,7 +5062,6 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 7,
       "links": [],
       "panels": [
         {
@@ -5091,16 +5188,32 @@ data:
             {
               "expr": "kos_agent_worker_count",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{ node }}",
+              "legendFormat": "ca @ {{ instance }}",
               "refId": "A"
+            },
+            {
+              "expr": "kos_ipam_worker_count",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "ipam @ {{ instance }}",
+              "refId": "B"
+            },
+            {
+              "expr": "kos_subnet_validator_worker_count ",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "sv @ {{ instance }}",
+              "refId": "C"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Number of CA Workers",
+          "title": "Number of Workers",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5150,7 +5263,7 @@ data:
             "x": 0,
             "y": 7
           },
-          "id": 2,
+          "id": 54,
           "legend": {
             "avg": false,
             "current": false,
@@ -5174,32 +5287,27 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_agent_queue_retries[1m])",
+              "expr": "rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m]) / ignoring (mismatch_type) group_left rate(kos_subnet_validator_queue_work_duration_count[1m])",
               "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "{{ mismatch_type }} mismatch / subnets processed",
               "refId": "A"
             },
             {
-              "expr": "rate(kos_ipam_controller_queue_retries[1m])",
+              "expr": "sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
               "format": "time_series",
+              "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "ipam @ {{ instance }}",
+              "legendFormat": "total mismatches / subnets processed",
               "refId": "B"
-            },
-            {
-              "expr": "rate(kos_subnet_validator_queue_retries[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "snval @ {{ instance }}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Requeue Rate",
+          "title": "Subnet Validator Conflicts Cache Mismatches to Subnets Processed",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5244,12 +5352,12 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
             "y": 14
           },
-          "id": 1,
+          "id": 52,
           "legend": {
             "avg": false,
             "current": false,
@@ -5273,32 +5381,18 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_agent_queue_adds[1m])",
+              "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_bucket[1m]))",
               "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
+              "intervalFactor": 1,
+              "legendFormat": "99%ile live list result length",
               "refId": "A"
-            },
-            {
-              "expr": "rate(kos_ipam_controller_queue_adds[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "ipam @ {{ instance }}",
-              "refId": "B"
-            },
-            {
-              "expr": "rate(kos_subnet_validator_queue_adds[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "snval @ {{ instance }}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Enqueue Rate",
+          "title": "Subnet Validator 99th Percentile Nbr of Subnets in Live Lists results",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5341,14 +5435,15 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 21
+            "y": 23
           },
-          "id": 3,
+          "id": 50,
           "legend": {
             "avg": false,
             "current": false,
@@ -5372,32 +5467,18 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(kos_agent_queue_queue_latency_count[1m])",
+              "expr": "rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_sum[1m]) / rate(kos_subnet_validator_number_of_subnets_returned_by_live_list_count[1m])",
               "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
+              "intervalFactor": 1,
+              "legendFormat": "subnet / live list",
               "refId": "A"
-            },
-            {
-              "expr": "rate(kos_ipam_controller_queue_queue_latency_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "ipam @ {{ instance }}",
-              "refId": "B"
-            },
-            {
-              "expr": "rate(kos_subnet_validator_queue_queue_latency_count[1m])",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "snval @ {{ instance }}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Dequeue Rate",
+          "title": "Subnet Validator Avg Nbr of Subnets in Live Lists Results",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5413,6 +5494,7 @@ data:
           },
           "yaxes": [
             {
+              "decimals": 1,
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -5421,6 +5503,7 @@ data:
               "show": true
             },
             {
+              "decimals": null,
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -5440,14 +5523,15 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "description": "Ratio of subnets for whom a status update was not needed because the status was already up-to-date to subnets processed.",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 10,
             "w": 24,
             "x": 0,
-            "y": 28
+            "y": 32
           },
-          "id": 13,
+          "id": 48,
           "legend": {
             "avg": false,
             "current": false,
@@ -5471,32 +5555,18 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "kos_agent_queue_depth",
+              "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
               "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "ca @ {{ instance }}",
+              "intervalFactor": 1,
+              "legendFormat": "up to date / processed",
               "refId": "A"
-            },
-            {
-              "expr": "kos_ipam_controller_queue_depth",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "ipam @ {{ instance }}",
-              "refId": "B"
-            },
-            {
-              "expr": "kos_subnet_validator_queue_depth",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "snval @ {{ instance }}",
-              "refId": "C"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Queue Length",
+          "title": "Subnet Validator Up to date Subnets to Processed Subnets",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5623,13 +5693,1033 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 48
+          },
+          "id": 36,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m])) without (err, statusErr)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "updates @ {{ instance }}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(kos_subnet_validator_live_list_latency_seconds_sum[1m])) without (err)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "lists @ {{ instance }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Worker Utilization for Calls Out, Summed over Workers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 57
+          },
+          "id": 34,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_queue_work_duration_sum[1m])/1.0e6",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "sv @ {{ instance }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Worker Utilization, Summed over Workers",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 63
+          },
+          "id": 46,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_stale_subnet_work_suppression_count[1m]) / rate(kos_subnet_validator_queue_work_duration_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "stale  / processed",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Stale Subnets Suppressions to Processed Subnets",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 72
+          },
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_queue_retries[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ca @ {{ instance }}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(kos_ipam_controller_queue_retries[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ipam @ {{ instance }}",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_queue_retries[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "sv @ {{ instance }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Requeue Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 79
+          },
+          "id": 1,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_queue_adds[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ca @ {{ instance }}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(kos_ipam_controller_queue_adds[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ipam @ {{ instance }}",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_queue_adds[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "sv @ {{ instance }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Enqueue Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 86
+          },
+          "id": 3,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_agent_queue_queue_latency_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ca @ {{ instance }}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(kos_ipam_controller_queue_queue_latency_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ipam @ {{ instance }}",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_queue_queue_latency_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "sv @ {{ instance }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Dequeue Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 93
+          },
+          "id": 13,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "kos_agent_queue_depth",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ca @ {{ instance }}",
+              "refId": "A"
+            },
+            {
+              "expr": "kos_ipam_controller_queue_depth",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "ipam @ {{ instance }}",
+              "refId": "B"
+            },
+            {
+              "expr": "kos_subnet_validator_queue_depth",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "sv @ {{ instance }}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Queue Length",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 100
+          },
+          "id": 40,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_subnet_update_latency_seconds_bucket[1m]))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }}  status update {{ statusErr }} {{ err }}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, rate(kos_subnet_validator_live_list_latency_seconds_bucket[1m]))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} live list {{ err }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "99th Percentile Subnet Validator Call Out Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 109
+          },
+          "id": 38,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_subnet_update_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} status update subnet={{ statusErr }} result={{ err }}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_live_list_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} live list {{ err }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Rate of Subnet Validator Call Outs",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "description": "When validating a subnet X, the Subnet Validator uses live lists to retrieve potentially conflicting subnets. Sometimes X's status is already up to date hence all processing including the live list was useless. This graph plots the ratio between useless live lists to the total of live lists.",
+          "fill": 1,
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 118
+          },
+          "id": 44,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_duplicate_work_count[1m]) + sum(rate(kos_subnet_validator_subnet_live_vs_conflict_cache_count[1m])) without (mismatch_type) / ignoring (err) rate(kos_subnet_validator_live_list_latency_seconds_count{err=\"ok\"}[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "useless / total successful @ {{ instance }} ",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Subnet Validator Useless Live Lists to Live Lists",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 128
+          },
+          "id": 42,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m]) / rate(kos_subnet_validator_subnet_update_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} status update {{ statusErr }} {{ err }}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(kos_subnet_validator_live_list_latency_seconds_sum[1m]) / rate(kos_subnet_validator_live_list_latency_seconds_count[1m])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ instance }} live list {{ err }}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average Subnet Validator Call Out Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
           "description": "Sum, over workers, of utilization of that worker",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 41
+            "y": 137
           },
           "id": 25,
           "legend": {
@@ -5714,7 +6804,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 48
+            "y": 144
           },
           "id": 27,
           "legend": {
@@ -5806,7 +6896,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 55
+            "y": 151
           },
           "id": 28,
           "legend": {
@@ -5898,7 +6988,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 62
+            "y": 158
           },
           "id": 30,
           "legend": {
@@ -5990,7 +7080,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 69
+            "y": 165
           },
           "id": 32,
           "legend": {
@@ -6082,7 +7172,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 76
+            "y": 172
           },
           "id": 4,
           "legend": {
@@ -6167,7 +7257,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 83
+            "y": 179
           },
           "id": 29,
           "legend": {
@@ -6252,7 +7342,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 90
+            "y": 186
           },
           "id": 31,
           "legend": {
@@ -6337,7 +7427,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 97
+            "y": 193
           },
           "id": 5,
           "legend": {
@@ -6422,7 +7512,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 104
+            "y": 200
           },
           "id": 6,
           "legend": {
@@ -6507,7 +7597,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 111
+            "y": 207
           },
           "id": 12,
           "legend": {
@@ -6592,7 +7682,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 118
+            "y": 214
           },
           "id": 14,
           "legend": {
@@ -6677,7 +7767,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 125
+            "y": 221
           },
           "id": 15,
           "legend": {
@@ -6762,7 +7852,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 132
+            "y": 228
           },
           "id": 16,
           "legend": {
@@ -6847,7 +7937,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 139
+            "y": 235
           },
           "id": 17,
           "legend": {
@@ -6932,7 +8022,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 146
+            "y": 242
           },
           "id": 7,
           "legend": {
@@ -7031,7 +8121,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 153
+            "y": 249
           },
           "id": 18,
           "legend": {
@@ -7116,7 +8206,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 160
+            "y": 256
           },
           "id": 19,
           "legend": {

--- a/staging/kos/pkg/controllers/ipam/ipam.go
+++ b/staging/kos/pkg/controllers/ipam/ipam.go
@@ -59,6 +59,9 @@ const (
 
 	fullSubnetErrMsgPrefix = "no IP address available in subnet"
 	fullSubnetStatusMsg    = "Referenced subnet has run out of IPs"
+
+	metricsNamespace = "kos"
+	metricsSubsystem = "ipam"
 )
 
 type IPAMController struct {
@@ -124,9 +127,7 @@ func NewController(netIfc kosclientv1a1.NetworkV1alpha1Interface,
 	eventIfc k8scorev1client.EventInterface,
 	queue k8sworkqueue.RateLimitingInterface,
 	workers int,
-	hostname string,
-	metricsNamespace string,
-	metricsSubsystem string) *IPAMController {
+	hostname string) *IPAMController {
 
 	attachmentCreateToLockHistogram := prometheus.NewHistogram(
 		prometheus.HistogramOpts{

--- a/staging/kos/pkg/controllers/subnet/validator.go
+++ b/staging/kos/pkg/controllers/subnet/validator.go
@@ -21,8 +21,11 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	k8scorev1api "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,20 +34,28 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	k8sutilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8swait "k8s.io/apimachinery/pkg/util/wait"
+	k8scorev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	k8scache "k8s.io/client-go/tools/cache"
+	k8seventrecord "k8s.io/client-go/tools/record"
 	k8sworkqueue "k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 
 	netv1a1 "k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1"
+	kosscheme "k8s.io/examples/staging/kos/pkg/client/clientset/versioned/scheme"
 	kosclientv1a1 "k8s.io/examples/staging/kos/pkg/client/clientset/versioned/typed/network/v1alpha1"
 	netlistv1a1 "k8s.io/examples/staging/kos/pkg/client/listers/network/v1alpha1"
 	"k8s.io/examples/staging/kos/pkg/util/parse"
 	"k8s.io/examples/staging/kos/pkg/util/parse/network/subnet"
 )
 
-// TODO: Add Prometheus metrics.
+const (
+	subnetVNIField = "spec.vni"
 
-const subnetVNIField = "spec.vni"
+	// label values for metrics tracking mismatches between conflicts caches and
+	// live lists results.
+	missingCacheMismatch = "missing cache"
+	cacheOwnerMismatch   = "cache owner"
+)
 
 // conflictsCache holds information for one subnet regarding conflicts with
 // other subnets. There's no guarantee that the cache is up-to-date. For
@@ -77,6 +88,7 @@ type Validator struct {
 	netIfc         kosclientv1a1.NetworkV1alpha1Interface
 	subnetInformer k8scache.SharedInformer
 	subnetLister   netlistv1a1.SubnetLister
+	eventRecorder  k8seventrecord.EventRecorder
 	queue          k8sworkqueue.RateLimitingInterface
 	workers        int
 
@@ -95,22 +107,152 @@ type Validator struct {
 	// Only access while holding staleRVsMutex.
 	staleRVs      map[k8stypes.NamespacedName]string
 	staleRVsMutex sync.RWMutex
+
+	// Latency from subnet ObjectMeta.CreationTimestamp to return from update
+	// writing validation outcome in status.
+	subnetCreateToValidatedHistograms *prometheus.HistogramVec
+
+	// Round trip time to update Subnet status.
+	subnetUpdateHistograms *prometheus.HistogramVec
+
+	// Round trip time of live lists to fetch subnets.
+	liveListHistograms *prometheus.HistogramVec
+
+	// Number of subnets returned by live lists.
+	liveListResultLengthHistogram prometheus.Histogram
+
+	// Number of times a worker processed a subnet all the way to the status
+	// update to find out that the status was already up to date.
+	duplicateWorkCount prometheus.Counter
+
+	// Number of times work on a subnet was suppressed because the subnet was
+	// stale.
+	staleSubnetsSuppressionCount prometheus.Counter
+
+	// Number of times the subnet received from the API server did not match the
+	// one owning the conflicts cache. This also counts cases where a subnet
+	// is received but the conflicts cache is not there.
+	cacheVsLiveSubnetMismatches *prometheus.CounterVec
 }
 
 func NewValidationController(netIfc kosclientv1a1.NetworkV1alpha1Interface,
 	subnetInformer k8scache.SharedInformer,
 	subnetLister netlistv1a1.SubnetLister,
+	eventIfc k8scorev1client.EventInterface,
 	queue k8sworkqueue.RateLimitingInterface,
-	workers int) *Validator {
+	workers int,
+	hostname string,
+	metricsNamespace string,
+	metricsSubsystem string) *Validator {
+
+	subnetCreateToValidatedHistograms := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "subnet_create_to_validated_latency_seconds",
+			Help:      "Latency from subnet CreationTimestamp to return from update writing validation outcome in status per outcome, in seconds.",
+			Buckets:   []float64{-1, 0, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 64},
+		},
+		[]string{"statusErr"})
+	errValT, errValF := FormatErrVal(true), FormatErrVal(false)
+	subnetCreateToValidatedHistograms.With(prometheus.Labels{"statusErr": errValT})
+	subnetCreateToValidatedHistograms.With(prometheus.Labels{"statusErr": errValF})
+
+	subnetUpdateHistograms := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "subnet_update_latency_seconds",
+			Help:      "Round trip time to update subnet status, in seconds.",
+			Buckets:   []float64{-0.125, 0, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64},
+		},
+		[]string{"err", "statusErr"})
+	subnetUpdateHistograms.With(prometheus.Labels{"err": errValT, "statusErr": errValT})
+	subnetUpdateHistograms.With(prometheus.Labels{"err": errValF, "statusErr": errValT})
+	subnetUpdateHistograms.With(prometheus.Labels{"err": errValT, "statusErr": errValF})
+	subnetUpdateHistograms.With(prometheus.Labels{"err": errValF, "statusErr": errValF})
+
+	liveListHistograms := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "live_list_latency_seconds",
+			Help:      "Round trip time of live lists to fetch subnets, in seconds.",
+			Buckets:   []float64{-0.125, 0, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64},
+		},
+		[]string{"err"})
+	liveListHistograms.With(prometheus.Labels{"err": errValT})
+	liveListHistograms.With(prometheus.Labels{"err": errValF})
+
+	liveListResultLengthHistogram := prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "number_of_subnets_returned_by_live_list",
+			Help:      "Number of subnets returned by live lists.",
+			Buckets:   []float64{-1, 0, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192},
+		})
+
+	duplicateWorkCount := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "duplicate_work_count",
+			Help:      "Number of times a subnet was processed but there was no status update because the status was already up to date.",
+		})
+
+	staleSubnetsSuppressionCount := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "stale_subnet_work_suppression_count",
+			Help:      "Number of times processing of a subnet stopped because the subnet was stale.",
+		})
+
+	cacheVsLiveSubnetMismatches := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "subnet_live_vs_conflict_cache_count",
+			Help:      "Number of times processing of a subnet stopped because of a mismatch between the subnet from the API server and the one associated with the conflicts cache.",
+		},
+		[]string{"mismatch_type"})
+	cacheVsLiveSubnetMismatches.With(prometheus.Labels{"mismatch_type": missingCacheMismatch})
+	cacheVsLiveSubnetMismatches.With(prometheus.Labels{"mismatch_type": cacheOwnerMismatch})
+
+	workerCount := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "worker_count",
+			Help:      "Number of queue worker threads",
+		})
+
+	prometheus.MustRegister(subnetCreateToValidatedHistograms, subnetUpdateHistograms, liveListHistograms, liveListResultLengthHistogram, duplicateWorkCount, staleSubnetsSuppressionCount, cacheVsLiveSubnetMismatches, workerCount)
+
+	workerCount.Add(float64(workers))
+
+	eventBroadcaster := k8seventrecord.NewBroadcaster()
+	eventBroadcaster.StartLogging(klog.V(3).Infof)
+	eventBroadcaster.StartRecordingToSink(&k8scorev1client.EventSinkImpl{eventIfc})
+	eventRecorder := eventBroadcaster.NewRecorder(kosscheme.Scheme, k8scorev1api.EventSource{Component: "subnet-validator", Host: hostname})
 
 	return &Validator{
-		netIfc:         netIfc,
-		subnetInformer: subnetInformer,
-		subnetLister:   subnetLister,
-		queue:          queue,
-		workers:        workers,
-		conflicts:      make(map[k8stypes.NamespacedName]*conflictsCache),
-		staleRVs:       make(map[k8stypes.NamespacedName]string),
+		netIfc:                            netIfc,
+		subnetInformer:                    subnetInformer,
+		subnetLister:                      subnetLister,
+		eventRecorder:                     eventRecorder,
+		subnetCreateToValidatedHistograms: subnetCreateToValidatedHistograms,
+		subnetUpdateHistograms:            subnetUpdateHistograms,
+		liveListHistograms:                liveListHistograms,
+		liveListResultLengthHistogram:     liveListResultLengthHistogram,
+		duplicateWorkCount:                duplicateWorkCount,
+		staleSubnetsSuppressionCount:      staleSubnetsSuppressionCount,
+		cacheVsLiveSubnetMismatches:       cacheVsLiveSubnetMismatches,
+		queue:                             queue,
+		workers:                           workers,
+		conflicts:                         make(map[k8stypes.NamespacedName]*conflictsCache),
+		staleRVs:                          make(map[k8stypes.NamespacedName]string),
 	}
 }
 
@@ -214,14 +356,13 @@ func (v *Validator) processQueueItem(subnet k8stypes.NamespacedName) {
 func (v *Validator) processSubnet(subnetNSN k8stypes.NamespacedName) error {
 	subnet, err := v.subnetLister.Subnets(subnetNSN.Namespace).Get(subnetNSN.Name)
 
-	if err != nil && !k8serrors.IsNotFound(err) {
-		klog.Errorf("Subnet lister failed to lookup %s: %s.", subnetNSN, err.Error())
-		// This should never happen. No point in retrying.
-		return nil
-	}
-
-	if k8serrors.IsNotFound(err) {
-		v.processDeletedSubnet(subnetNSN)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			v.processDeletedSubnet(subnetNSN)
+		} else {
+			// This should never happen. No point in retrying.
+			klog.Errorf("Subnet lister failed to lookup %s: %s.", subnetNSN, err.Error())
+		}
 		return nil
 	}
 
@@ -249,6 +390,7 @@ func (v *Validator) processExistingSubnet(s *netv1a1.Subnet) error {
 
 	if v.subnetIsStale(ss.NamespacedName, s.ResourceVersion) {
 		klog.V(5).Infof("Stopping processing of %s because it's stale. Processing will be restarted upon receiving the fresh version.", ss.NamespacedName)
+		v.staleSubnetsSuppressionCount.Inc()
 		return nil
 	}
 
@@ -270,9 +412,13 @@ func (v *Validator) processExistingSubnet(s *netv1a1.Subnet) error {
 	// Retrieve all the subnets with the same VNI as s. Doing a live list as
 	// opposed to a cache-based one (through the informer) prevents race
 	// conditions that can arise in case of multiple validators running.
+	tBefore := time.Now()
 	potentialRivals, err := v.netIfc.Subnets(k8scorev1api.NamespaceAll).List(k8smetav1.ListOptions{
 		FieldSelector: k8sfields.OneTermEqualSelector(subnetVNIField, strconv.FormatUint(uint64(ss.VNI), 10)).String(),
 	})
+	tAfter := time.Now()
+	v.liveListHistograms.With(prometheus.Labels{"err": FormatErrVal(err != nil)}).Observe(tAfter.Sub(tBefore).Seconds())
+	v.liveListResultLengthHistogram.Observe(float64(len(potentialRivals.Items)))
 	if err != nil {
 		if malformedRequest(err) {
 			klog.Errorf("live list of all subnets against API server failed while validating %s: %s. There will be no retry because of the nature of the error", ss.NamespacedName, err.Error())
@@ -399,46 +545,66 @@ func (v *Validator) recordConflicts(candidate *subnet.Summary, potentialRivals [
 	return
 }
 
-func (v *Validator) updateSubnetValidity(s *netv1a1.Subnet, validationErrors []string) error {
+func (v *Validator) updateSubnetValidity(s1 *netv1a1.Subnet, validationErrors []string) error {
 	// Check if s's status needs an update.
 	sort.Strings(validationErrors)
 	validated := len(validationErrors) == 0
-	if s.Status.Validated == validated && equal(s.Status.Errors, validationErrors) {
-		klog.V(4).Infof("%s/%s's status was not updated because it is already up to date.", s.Namespace, s.Name)
+	if s1.Status.Validated == validated && equal(s1.Status.Errors, validationErrors) {
+		klog.V(4).Infof("%s/%s's status was not updated because it is already up to date.", s1.Namespace, s1.Name)
+		v.duplicateWorkCount.Inc()
 		return nil
 	}
 
-	sCopy := s.DeepCopy()
-	sCopy.Status.Validated = validated
-	sCopy.Status.Errors = validationErrors
+	s2 := s1.DeepCopy()
+	s2.Status.Validated = validated
+	s2.Status.Errors = validationErrors
 
-	_, err := v.netIfc.Subnets(sCopy.Namespace).Update(sCopy)
+	tBefore := time.Now()
+	s3, err := v.netIfc.Subnets(s2.Namespace).Update(s2)
+	tAfter := time.Now()
+	v.subnetUpdateHistograms.With(prometheus.Labels{"err": FormatErrVal(err != nil), "statusErr": FormatErrVal(len(validationErrors) > 0)}).Observe(tAfter.Sub(tBefore).Seconds())
 	switch {
 	case err == nil:
 		nsn := k8stypes.NamespacedName{
-			Namespace: s.Namespace,
-			Name:      s.Name,
+			Namespace: s1.Namespace,
+			Name:      s1.Name,
 		}
-		klog.V(4).Infof("Recorded errors=%s and validated=%t into %s's status.", validationErrors, sCopy.Status.Validated, nsn)
-		v.updateStaleRV(nsn, s.ResourceVersion)
+		klog.V(4).Infof("Recorded errors=%s and validated=%t into %s's status.", validationErrors, s2.Status.Validated, nsn)
+		v.updateStaleRV(nsn, s1.ResourceVersion)
+		if !s1.Status.Validated && len(s1.Status.Errors) == 0 {
+			v.subnetCreateToValidatedHistograms.With(prometheus.Labels{"statusErr": FormatErrVal(len(validationErrors) > 0)}).Observe(tAfter.Sub(s1.CreationTimestamp.Time).Seconds())
+		}
+		if validated {
+			v.eventRecorder.Event(s3, k8scorev1api.EventTypeNormal, "SubnetValidated", "")
+		} else {
+			v.eventRecorder.Eventf(s3, k8scorev1api.EventTypeWarning, "SubnetFailedValidation", "Found rival subnets: %s", strings.Join(validationErrors, ", "))
+		}
 	case malformedRequest(err):
-		klog.Errorf("Failed update from %#+v to %#+v: %s; there will be no retry because of the nature of the error.", s, sCopy, err.Error())
+		klog.Errorf("Failed update from %#+v to %#+v: %s; there will be no retry because of the nature of the error.", s1, s2, err.Error())
 	default:
-		return fmt.Errorf("failed update from %#+v to %#+v: %s", s, sCopy, err.Error())
+		return fmt.Errorf("failed update from %#+v to %#+v: %s", s1, s2, err.Error())
 	}
 
 	return nil
 }
 
 func (v *Validator) recordConflict(enrollerNSN, enrolleeNSN k8stypes.NamespacedName, enrollerUID k8stypes.UID) error {
+	mismatchType := ""
+
 	v.conflictsMutex.Lock()
-	defer v.conflictsMutex.Unlock()
+	defer func() {
+		v.conflictsMutex.Unlock()
+		if mismatchType != "" {
+			v.cacheVsLiveSubnetMismatches.With(prometheus.Labels{"mismatch_type": mismatchType}).Inc()
+		}
+	}()
 
 	c := v.conflicts[enrollerNSN]
 	if c == nil {
 		// Either enroller has been deleted and its deletion has been processed
 		// between the live list and now, or its creation has not been processed
 		// yet. Retry after some time so that the ambiguity is resolved.
+		mismatchType = missingCacheMismatch
 		return fmt.Errorf("registration as %s's rival failed: conflicts cache not found", enrollerNSN)
 	}
 	if c.ownerUID != enrollerUID {
@@ -452,6 +618,7 @@ func (v *Validator) recordConflict(enrollerNSN, enrolleeNSN k8stypes.NamespacedN
 		// namespaced name has been created and processed by this controller.
 		// Since it is not known what happened, return an error that will
 		// trigger a delayed retry. Hopefully time will resolve the ambiguity.
+		mismatchType = cacheOwnerMismatch
 		return fmt.Errorf("registration as %s's rival failed: mismatch between live data (enroller's UID: %s) and conflicts cache data (owner's UID: %s)", enrollerNSN, enrollerUID, c.ownerUID)
 	}
 
@@ -477,4 +644,12 @@ func equal(s1, s2 []string) bool {
 		}
 	}
 	return true
+}
+
+// TODO move to shared util pkg
+func FormatErrVal(err bool) string {
+	if err {
+		return "err"
+	}
+	return "ok"
 }

--- a/staging/kos/pkg/controllers/subnet/validator.go
+++ b/staging/kos/pkg/controllers/subnet/validator.go
@@ -55,6 +55,9 @@ const (
 	// live lists results.
 	missingCacheMismatch = "missing cache"
 	cacheOwnerMismatch   = "cache owner"
+
+	metricsNamespace = "kos"
+	metricsSubsystem = "subnet_validator"
 )
 
 // conflictsCache holds information for one subnet regarding conflicts with
@@ -141,9 +144,7 @@ func NewValidationController(netIfc kosclientv1a1.NetworkV1alpha1Interface,
 	eventIfc k8scorev1client.EventInterface,
 	queue k8sworkqueue.RateLimitingInterface,
 	workers int,
-	hostname string,
-	metricsNamespace string,
-	metricsSubsystem string) *Validator {
+	hostname string) *Validator {
 
 	subnetCreateToValidatedHistograms := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/staging/kos/pkg/controllers/workqueue_prometheus/connect.go
+++ b/staging/kos/pkg/controllers/workqueue_prometheus/connect.go
@@ -30,8 +30,9 @@ import (
 // Package prometheus sets the workqueue DefaultMetricsFactory to produce
 // prometheus metrics. To use this package, you just have to import it.
 
-// Metrics subsystem and keys used by the workqueue.
+// Metrics namespace, subsystem and keys used by the workqueue.
 const (
+	WorkQueueNamespace         = "kos"
 	WorkQueueSubsystem         = "workqueue"
 	DepthKey                   = "depth"
 	AddsKey                    = "adds_total"
@@ -50,6 +51,7 @@ type prometheusMetricsProvider struct{}
 
 func (prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
 	depth := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   WorkQueueNamespace,
 		Subsystem:   WorkQueueSubsystem,
 		Name:        DepthKey,
 		Help:        "Current depth of workqueue",
@@ -61,6 +63,7 @@ func (prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetr
 
 func (prometheusMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
 	adds := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   WorkQueueNamespace,
 		Subsystem:   WorkQueueSubsystem,
 		Name:        AddsKey,
 		Help:        "Total number of adds handled by workqueue",
@@ -72,6 +75,7 @@ func (prometheusMetricsProvider) NewAddsMetric(name string) workqueue.CounterMet
 
 func (prometheusMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
 	latency := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace:   WorkQueueNamespace,
 		Subsystem:   WorkQueueSubsystem,
 		Name:        QueueLatencyKey,
 		Help:        "How long in seconds an item stays in workqueue before being requested.",
@@ -84,6 +88,7 @@ func (prometheusMetricsProvider) NewLatencyMetric(name string) workqueue.Histogr
 
 func (prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
 	workDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace:   WorkQueueNamespace,
 		Subsystem:   WorkQueueSubsystem,
 		Name:        WorkDurationKey,
 		Help:        "How long in seconds processing an item from workqueue takes.",
@@ -96,6 +101,7 @@ func (prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.Hi
 
 func (prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
 	unfinished := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: WorkQueueNamespace,
 		Subsystem: WorkQueueSubsystem,
 		Name:      UnfinishedWorkKey,
 		Help: "How many seconds of work has done that " +
@@ -110,6 +116,7 @@ func (prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) wor
 
 func (prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
 	unfinished := prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: WorkQueueNamespace,
 		Subsystem: WorkQueueSubsystem,
 		Name:      LongestRunningProcessorKey,
 		Help: "How many seconds has the longest running " +
@@ -122,6 +129,7 @@ func (prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name st
 
 func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
 	retries := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   WorkQueueNamespace,
 		Subsystem:   WorkQueueSubsystem,
 		Name:        RetriesKey,
 		Help:        "Total number of retries handled by workqueue",


### PR DESCRIPTION
Make Subnet Validator produce Prometheus metrics and K8s API events.
Add Grafana Dashboards and tweak existing ones to reflect the change.
Tweak IPAM Prometheus metrics. Do not apply the same tweaks to the
Connection Agent because it will be heavily refactored soon.