### PR TITLE
Pay some technical debt

### DIFF
--- a/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
+++ b/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
@@ -464,10 +464,10 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "description": "Sum, over workers, of utilization of that worker",
+      "description": "",
       "fill": 1,
       "gridPos": {
-        "h": 9,
+        "h": 10,
         "w": 24,
         "x": 0,
         "y": 23
@@ -499,108 +499,29 @@
           "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"sv\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ instance  }}",
+          "legendFormat": "total work",
           "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Subnet Validator Worker Utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
         },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "description": "Sum, over workers, of utilization of that worker spent on calls out.",
-      "fill": 1,
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 32
-      },
-      "id": 36,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
         {
           "expr": "sum(rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m])) without (err, statusErr)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "updates @ {{ instance }}",
-          "refId": "A"
+          "legendFormat": "spent on updates",
+          "refId": "B"
         },
         {
           "expr": "sum(rate(kos_subnet_validator_live_list_latency_seconds_sum[1m])) without (err)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "lists @ {{ instance }}",
-          "refId": "B"
+          "legendFormat": "spent on live lists",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Subnet Validator Worker Utilization for Calls Out",
+      "title": "Subnet Validator Worker Utilization, Summed Over Workers",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -648,7 +569,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 33
       },
       "id": 40,
       "legend": {
@@ -740,7 +661,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 44
       },
       "id": 42,
       "legend": {
@@ -832,7 +753,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 53
       },
       "id": 38,
       "legend": {
@@ -925,7 +846,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 62
       },
       "id": 44,
       "legend": {
@@ -1031,7 +952,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 72
       },
       "id": 46,
       "legend": {
@@ -1116,7 +1037,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 81
       },
       "id": 52,
       "legend": {
@@ -1202,7 +1123,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 98
+        "y": 90
       },
       "id": 50,
       "legend": {
@@ -1284,13 +1205,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "description": "Sum, over workers, of utilization of that worker",
+      "description": "",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 99
       },
       "id": 25,
       "legend": {
@@ -1319,108 +1240,29 @@
           "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"ipam\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ instance }}",
+          "legendFormat": "total work",
           "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "IPAM Worker Utilization Sum",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
         },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
-      "description": "Sum, over workers, of utilization of that worker spent on calls out.",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 115
-      },
-      "id": 27,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
         {
           "expr": "sum(rate(kos_ipam_attachment_update_latency_seconds_sum[1m])) without (err, statusErr)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "attachments @ {{ instance }}",
-          "refId": "A"
+          "legendFormat": "spent on attachment updates",
+          "refId": "B"
         },
         {
           "expr": "sum(rate(kos_ipam_ip_lock_latency_seconds_sum[1m])) without (op, err)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "locks @ {{ instance }}",
-          "refId": "B"
+          "legendFormat": "spent on lock ops",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "IPAM Worker Utilization Sum For Calls Out",
+      "title": "IPAM Worker Utilization, Summed Over Workers",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1468,7 +1310,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 122
+        "y": 107
       },
       "id": 28,
       "legend": {
@@ -1560,7 +1402,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 129
+        "y": 114
       },
       "id": 32,
       "legend": {
@@ -1652,7 +1494,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 136
+        "y": 121
       },
       "id": 30,
       "legend": {
@@ -1744,7 +1586,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 143
+        "y": 128
       },
       "id": 7,
       "legend": {
@@ -1843,7 +1685,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 150
+        "y": 135
       },
       "id": 21,
       "legend": {
@@ -1923,13 +1765,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "description": "Sum, over workers, of utilization of that worker",
+      "description": "",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 157
+        "y": 142
       },
       "id": 4,
       "legend": {
@@ -1966,7 +1808,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Connection Agent Worker Utilization",
+      "title": "Connection Agent Worker Utilization, Summed Over Workers",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2014,7 +1856,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 164
+        "y": 149
       },
       "id": 5,
       "legend": {
@@ -2099,7 +1941,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 171
+        "y": 156
       },
       "id": 29,
       "legend": {
@@ -2184,7 +2026,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 178
+        "y": 163
       },
       "id": 31,
       "legend": {
@@ -2269,7 +2111,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 185
+        "y": 170
       },
       "id": 6,
       "legend": {
@@ -2354,7 +2196,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 192
+        "y": 177
       },
       "id": 12,
       "legend": {
@@ -2439,7 +2281,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 199
+        "y": 184
       },
       "id": 14,
       "legend": {
@@ -2524,7 +2366,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 206
+        "y": 191
       },
       "id": 15,
       "legend": {
@@ -2609,7 +2451,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 213
+        "y": 198
       },
       "id": 16,
       "legend": {
@@ -2694,7 +2536,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 220
+        "y": 205
       },
       "id": 17,
       "legend": {
@@ -2779,7 +2621,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 227
+        "y": 212
       },
       "id": 18,
       "legend": {
@@ -2864,7 +2706,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 234
+        "y": 219
       },
       "id": 19,
       "legend": {

--- a/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
+++ b/staging/kos/metrics/grafana/dashboard-defs/kos-internals.json
@@ -25,8 +25,8 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
-        "w": 24,
+        "h": 10,
+        "w": 12,
         "x": 0,
         "y": 0
       },
@@ -126,10 +126,95 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 21,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(kos_agent_fabric_count) by (fabric)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ fabric }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Number of CA, By Fabric Name",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
         "x": 0,
-        "y": 7
+        "y": 10
       },
       "id": 1,
       "legend": {
@@ -211,10 +296,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 7
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 19
       },
       "id": 3,
       "legend": {
@@ -296,10 +381,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 10,
+        "w": 24,
         "x": 0,
-        "y": 15
+        "y": 28
       },
       "id": 2,
       "legend": {
@@ -381,10 +466,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 15
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 38
       },
       "id": 13,
       "legend": {
@@ -470,7 +555,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 47
       },
       "id": 56,
       "legend": {
@@ -499,7 +584,7 @@
           "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"sv\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "total work",
+          "legendFormat": "total",
           "refId": "A"
         },
         {
@@ -569,7 +654,7 @@
         "h": 11,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 57
       },
       "id": 40,
       "legend": {
@@ -661,7 +746,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 68
       },
       "id": 42,
       "legend": {
@@ -753,7 +838,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 77
       },
       "id": 38,
       "legend": {
@@ -846,7 +931,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 86
       },
       "id": 44,
       "legend": {
@@ -952,7 +1037,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 96
       },
       "id": 46,
       "legend": {
@@ -1037,7 +1122,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 105
       },
       "id": 52,
       "legend": {
@@ -1123,7 +1208,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 90
+        "y": 114
       },
       "id": 50,
       "legend": {
@@ -1208,10 +1293,10 @@
       "description": "",
       "fill": 1,
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 99
+        "y": 123
       },
       "id": 25,
       "legend": {
@@ -1240,7 +1325,7 @@
           "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"ipam\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "total work",
+          "legendFormat": "total",
           "refId": "A"
         },
         {
@@ -1307,10 +1392,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 107
+        "y": 132
       },
       "id": 28,
       "legend": {
@@ -1399,10 +1484,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 24,
         "x": 0,
-        "y": 114
+        "y": 141
       },
       "id": 32,
       "legend": {
@@ -1491,10 +1576,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 121
+        "y": 149
       },
       "id": 30,
       "legend": {
@@ -1583,10 +1668,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 24,
         "x": 0,
-        "y": 128
+        "y": 158
       },
       "id": 7,
       "legend": {
@@ -1680,98 +1765,13 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 135
-      },
-      "id": 21,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(kos_agent_fabric_count) by (fabric)",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "{{ fabric }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Number of CA, By Fabric Name",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
       "description": "",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 24,
         "x": 0,
-        "y": 142
+        "y": 166
       },
       "id": 4,
       "legend": {
@@ -1853,10 +1853,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 24,
         "x": 0,
-        "y": 149
+        "y": 176
       },
       "id": 5,
       "legend": {
@@ -1938,10 +1938,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 156
+        "y": 186
       },
       "id": 29,
       "legend": {
@@ -2023,10 +2023,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 24,
         "x": 0,
-        "y": 163
+        "y": 195
       },
       "id": 31,
       "legend": {
@@ -2108,10 +2108,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 170
+        "y": 205
       },
       "id": 6,
       "legend": {
@@ -2193,10 +2193,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 177
+        "y": 214
       },
       "id": 12,
       "legend": {
@@ -2278,10 +2278,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 184
+        "y": 223
       },
       "id": 14,
       "legend": {
@@ -2363,10 +2363,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 191
+        "y": 232
       },
       "id": 15,
       "legend": {
@@ -2448,10 +2448,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 198
+        "y": 241
       },
       "id": 16,
       "legend": {
@@ -2533,10 +2533,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 205
+        "y": 250
       },
       "id": 17,
       "legend": {
@@ -2618,10 +2618,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 24,
         "x": 0,
-        "y": 212
+        "y": 259
       },
       "id": 18,
       "legend": {
@@ -2703,10 +2703,10 @@
       "datasource": "prometheus",
       "fill": 1,
       "gridPos": {
-        "h": 7,
+        "h": 10,
         "w": 24,
         "x": 0,
-        "y": 219
+        "y": 269
       },
       "id": 19,
       "legend": {

--- a/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
+++ b/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
@@ -5073,8 +5073,8 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
-            "w": 24,
+            "h": 10,
+            "w": 12,
             "x": 0,
             "y": 0
           },
@@ -5174,10 +5174,95 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 8,
+            "h": 10,
             "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 21,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(kos_agent_fabric_count) by (fabric)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{ fabric }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of CA, By Fabric Name",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "fill": 1,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
             "x": 0,
-            "y": 7
+            "y": 10
           },
           "id": 1,
           "legend": {
@@ -5259,10 +5344,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 7
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 19
           },
           "id": 3,
           "legend": {
@@ -5344,10 +5429,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 8,
-            "w": 12,
+            "h": 10,
+            "w": 24,
             "x": 0,
-            "y": 15
+            "y": 28
           },
           "id": 2,
           "legend": {
@@ -5429,10 +5514,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 15
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 38
           },
           "id": 13,
           "legend": {
@@ -5518,7 +5603,7 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 23
+            "y": 47
           },
           "id": 56,
           "legend": {
@@ -5547,7 +5632,7 @@ data:
               "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"sv\"}[1m])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "total work",
+              "legendFormat": "total",
               "refId": "A"
             },
             {
@@ -5617,7 +5702,7 @@ data:
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 57
           },
           "id": 40,
           "legend": {
@@ -5709,7 +5794,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 68
           },
           "id": 42,
           "legend": {
@@ -5801,7 +5886,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 53
+            "y": 77
           },
           "id": 38,
           "legend": {
@@ -5894,7 +5979,7 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 62
+            "y": 86
           },
           "id": 44,
           "legend": {
@@ -6000,7 +6085,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 72
+            "y": 96
           },
           "id": 46,
           "legend": {
@@ -6085,7 +6170,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 105
           },
           "id": 52,
           "legend": {
@@ -6171,7 +6256,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 90
+            "y": 114
           },
           "id": 50,
           "legend": {
@@ -6256,10 +6341,10 @@ data:
           "description": "",
           "fill": 1,
           "gridPos": {
-            "h": 8,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 99
+            "y": 123
           },
           "id": 25,
           "legend": {
@@ -6288,7 +6373,7 @@ data:
               "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"ipam\"}[1m])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "total work",
+              "legendFormat": "total",
               "refId": "A"
             },
             {
@@ -6355,10 +6440,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 107
+            "y": 132
           },
           "id": 28,
           "legend": {
@@ -6447,10 +6532,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 24,
             "x": 0,
-            "y": 114
+            "y": 141
           },
           "id": 32,
           "legend": {
@@ -6539,10 +6624,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 121
+            "y": 149
           },
           "id": 30,
           "legend": {
@@ -6631,10 +6716,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 8,
             "w": 24,
             "x": 0,
-            "y": 128
+            "y": 158
           },
           "id": 7,
           "legend": {
@@ -6728,98 +6813,13 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 135
-          },
-          "id": 21,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(kos_agent_fabric_count) by (fabric)",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "legendFormat": "{{ fabric }}",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Number of CA, By Fabric Name",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
           "description": "",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 10,
             "w": 24,
             "x": 0,
-            "y": 142
+            "y": 166
           },
           "id": 4,
           "legend": {
@@ -6901,10 +6901,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 10,
             "w": 24,
             "x": 0,
-            "y": 149
+            "y": 176
           },
           "id": 5,
           "legend": {
@@ -6986,10 +6986,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 156
+            "y": 186
           },
           "id": 29,
           "legend": {
@@ -7071,10 +7071,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 10,
             "w": 24,
             "x": 0,
-            "y": 163
+            "y": 195
           },
           "id": 31,
           "legend": {
@@ -7156,10 +7156,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 170
+            "y": 205
           },
           "id": 6,
           "legend": {
@@ -7241,10 +7241,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 177
+            "y": 214
           },
           "id": 12,
           "legend": {
@@ -7326,10 +7326,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 184
+            "y": 223
           },
           "id": 14,
           "legend": {
@@ -7411,10 +7411,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 191
+            "y": 232
           },
           "id": 15,
           "legend": {
@@ -7496,10 +7496,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 198
+            "y": 241
           },
           "id": 16,
           "legend": {
@@ -7581,10 +7581,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 9,
             "w": 24,
             "x": 0,
-            "y": 205
+            "y": 250
           },
           "id": 17,
           "legend": {
@@ -7666,10 +7666,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 10,
             "w": 24,
             "x": 0,
-            "y": 212
+            "y": 259
           },
           "id": 18,
           "legend": {
@@ -7751,10 +7751,10 @@ data:
           "datasource": "prometheus",
           "fill": 1,
           "gridPos": {
-            "h": 7,
+            "h": 10,
             "w": 24,
             "x": 0,
-            "y": 219
+            "y": 269
           },
           "id": 19,
           "legend": {

--- a/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
+++ b/staging/kos/metrics/grafana/manifests/configmap-dashboard-defs.yaml
@@ -5512,10 +5512,10 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "description": "Sum, over workers, of utilization of that worker",
+          "description": "",
           "fill": 1,
           "gridPos": {
-            "h": 9,
+            "h": 10,
             "w": 24,
             "x": 0,
             "y": 23
@@ -5547,108 +5547,29 @@ data:
               "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"sv\"}[1m])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{ instance  }}",
+              "legendFormat": "total work",
               "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Subnet Validator Worker Utilization",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
             },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "description": "Sum, over workers, of utilization of that worker spent on calls out.",
-          "fill": 1,
-          "gridPos": {
-            "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 32
-          },
-          "id": 36,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
             {
               "expr": "sum(rate(kos_subnet_validator_subnet_update_latency_seconds_sum[1m])) without (err, statusErr)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "updates @ {{ instance }}",
-              "refId": "A"
+              "legendFormat": "spent on updates",
+              "refId": "B"
             },
             {
               "expr": "sum(rate(kos_subnet_validator_live_list_latency_seconds_sum[1m])) without (err)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "lists @ {{ instance }}",
-              "refId": "B"
+              "legendFormat": "spent on live lists",
+              "refId": "C"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Subnet Validator Worker Utilization for Calls Out",
+          "title": "Subnet Validator Worker Utilization, Summed Over Workers",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -5696,7 +5617,7 @@ data:
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 41
+            "y": 33
           },
           "id": 40,
           "legend": {
@@ -5788,7 +5709,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 52
+            "y": 44
           },
           "id": 42,
           "legend": {
@@ -5880,7 +5801,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 61
+            "y": 53
           },
           "id": 38,
           "legend": {
@@ -5973,7 +5894,7 @@ data:
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 70
+            "y": 62
           },
           "id": 44,
           "legend": {
@@ -6079,7 +6000,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 80
+            "y": 72
           },
           "id": 46,
           "legend": {
@@ -6164,7 +6085,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 89
+            "y": 81
           },
           "id": 52,
           "legend": {
@@ -6250,7 +6171,7 @@ data:
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 98
+            "y": 90
           },
           "id": 50,
           "legend": {
@@ -6332,13 +6253,13 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "description": "Sum, over workers, of utilization of that worker",
+          "description": "",
           "fill": 1,
           "gridPos": {
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 107
+            "y": 99
           },
           "id": 25,
           "legend": {
@@ -6367,108 +6288,29 @@ data:
               "expr": "rate(kos_workqueue_work_duration_seconds_sum{name=\"ipam\"}[1m])",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{ instance }}",
+              "legendFormat": "total work",
               "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "IPAM Worker Utilization Sum",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
             },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "description": "Sum, over workers, of utilization of that worker spent on calls out.",
-          "fill": 1,
-          "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
-            "y": 115
-          },
-          "id": 27,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
             {
               "expr": "sum(rate(kos_ipam_attachment_update_latency_seconds_sum[1m])) without (err, statusErr)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "attachments @ {{ instance }}",
-              "refId": "A"
+              "legendFormat": "spent on attachment updates",
+              "refId": "B"
             },
             {
               "expr": "sum(rate(kos_ipam_ip_lock_latency_seconds_sum[1m])) without (op, err)",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "locks @ {{ instance }}",
-              "refId": "B"
+              "legendFormat": "spent on lock ops",
+              "refId": "C"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "IPAM Worker Utilization Sum For Calls Out",
+          "title": "IPAM Worker Utilization, Summed Over Workers",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -6516,7 +6358,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 122
+            "y": 107
           },
           "id": 28,
           "legend": {
@@ -6608,7 +6450,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 129
+            "y": 114
           },
           "id": 32,
           "legend": {
@@ -6700,7 +6542,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 136
+            "y": 121
           },
           "id": 30,
           "legend": {
@@ -6792,7 +6634,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 143
+            "y": 128
           },
           "id": 7,
           "legend": {
@@ -6891,7 +6733,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 150
+            "y": 135
           },
           "id": 21,
           "legend": {
@@ -6971,13 +6813,13 @@ data:
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "description": "Sum, over workers, of utilization of that worker",
+          "description": "",
           "fill": 1,
           "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 157
+            "y": 142
           },
           "id": 4,
           "legend": {
@@ -7014,7 +6856,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Connection Agent Worker Utilization",
+          "title": "Connection Agent Worker Utilization, Summed Over Workers",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -7062,7 +6904,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 164
+            "y": 149
           },
           "id": 5,
           "legend": {
@@ -7147,7 +6989,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 171
+            "y": 156
           },
           "id": 29,
           "legend": {
@@ -7232,7 +7074,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 178
+            "y": 163
           },
           "id": 31,
           "legend": {
@@ -7317,7 +7159,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 185
+            "y": 170
           },
           "id": 6,
           "legend": {
@@ -7402,7 +7244,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 192
+            "y": 177
           },
           "id": 12,
           "legend": {
@@ -7487,7 +7329,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 199
+            "y": 184
           },
           "id": 14,
           "legend": {
@@ -7572,7 +7414,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 206
+            "y": 191
           },
           "id": 15,
           "legend": {
@@ -7657,7 +7499,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 213
+            "y": 198
           },
           "id": 16,
           "legend": {
@@ -7742,7 +7584,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 220
+            "y": 205
           },
           "id": 17,
           "legend": {
@@ -7827,7 +7669,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 227
+            "y": 212
           },
           "id": 18,
           "legend": {
@@ -7912,7 +7754,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 234
+            "y": 219
           },
           "id": 19,
           "legend": {

--- a/staging/kos/pkg/registry/network/subnet/strategy.go
+++ b/staging/kos/pkg/registry/network/subnet/strategy.go
@@ -137,6 +137,10 @@ func (ss *subnetStrategy) checkNSAndCIDRConflicts(candidate *subnet.Summary) (er
 	// Check whether there are Namespace and CIDR conflicts with other subnets.
 	for _, potentialRival := range potentialRivals {
 		pr, err := subnet.NewSummary(potentialRival)
+		// Make sure potentialRival is well formed. The code in this file makes
+		// it impossible to create a malformed subnet, but the check is done in
+		// case this version of strategy is rolled out after a more lenient one
+		// which let malformed subnets through.
 		if err != nil {
 			prMeta := potentialRival.(k8smetav1.Object)
 			klog.V(6).Infof("Skipping %s/%s while validating %s because parsing failed: %s.", prMeta.GetNamespace(), prMeta.GetName(), candidate.NamespacedName, err.Error())


### PR DESCRIPTION
**Merge #76 first**

This PR was rebased on the pulled branch from #76, it's WIP because #76 has not been merged yet.
 
**What does this PR do**

- Tweak Grafana dashboards for IPAM and Subnet Validator as described [here](https://github.com/MikeSpreitzer/kube-examples/pull/75#issuecomment-514646405): merge dashboards about worker utilization and worker utilization spent on calls out. Tweaks and additions concerning the Connection Agent are left for after the refactoring of said controller. 
- Add explanatory comment in subnet strategy code.