### PR TITLE
Fix cookie generation: make it collision free 

### DIFF
--- a/staging/kos/pkg/networkfabric/ovs/ovs.go
+++ b/staging/kos/pkg/networkfabric/ovs/ovs.go
@@ -23,7 +23,6 @@ limitations under the License.
 package ovs
 
 import (
-	"encoding/binary"
 	"fmt"
 	"net"
 	"os/exec"
@@ -510,7 +509,7 @@ func (f *ovsFabric) addRemoteIfcFlows(tunID uint32, dlDst net.HardwareAddr, tunD
 	// fields in the two flows created do not overlap. Without it it's
 	// impossible to pair remote flows that were originated by the same interface,
 	// but we need this coupling at remote interfaces list time.
-	cookie, _ := binary.Uvarint(dlDst)
+	cookie := convert.MACAddressToUint64(dlDst)
 
 	dlTrafficFlow := fmt.Sprintf("table=1,cookie=%d,tun_id=%#x,dl_dst=%s,actions=set_field:%s->tun_dst,output:%d",
 		cookie,

--- a/staging/kos/pkg/util/convert/mac.go
+++ b/staging/kos/pkg/util/convert/mac.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package convert
+
+import (
+	"net"
+)
+
+// MACAddressToUint64 encodes a MAC address in a uint64.
+// NOTE: It assumes that `mac` fits in 64 bits.
+func MACAddressToUint64(mac net.HardwareAddr) (v uint64) {
+	var shift uint64 = 256
+	for _, b := range mac {
+		v = v*shift + uint64(b)
+	}
+	return
+}


### PR DESCRIPTION
Cookies are an OvS mechanism to allow arbitrary grouping of OpenFlow flows. A cookie is a key value pair in a flow whose key is "cookie". Flows with the same value for "cookie" are in the same "group".

When the connection agent is started, it syncs the pre-existing interfaces. This requires listing of pre-existing remote interfaces from the fabric. The hard state for remote network interfaces consists of OpenFlow flows; there are two for each remote interface. Therefore, when listing network interfaces the two flows for each remote interface must be parsed into said interface. This requires pairing each flow to the one that was added for the same remote interface. The fields that are strictly necessary in the two flows for a remote interface do not overlap. This means that without "something more" once flows for a remote interface are added there's no way to pair them back. The fabric uses cookies as that "something more": the two flows added for a remote interface have the same cookie.  For the list of remote interfaces to work, it's not enough to match each flow to the one added for the same remote interface: it must be matched ONLY to that flow. That is, cookies must be unique across existing remote interfaces. Because MAC addresses must also be unique for network interfaces the fabric computes the cookie for a remote interface as a function of the interface MAC address. But the fabric makes a critical mistake: the function that computes cookies is not collision-free. Flows added for different remote interfaces CAN have the same cookie. The reason is that the [function](https://godoc.org/encoding/binary#Uvarint) used to produce cookies interprets the input MAC address (of type net.HardwareAddr) as compliant with the format described [here](https://developers.google.com/protocol-buffers/docs/encoding). The consequence (which depends on other implementation details of the fabric as well) is that if N remote interfaces with the same cookie were created, only 1 remote interface is returned by the list of remote interfaces, and it might differ from every one of the N interfaces.  This makes the initial sync of network interfaces (badly) wrong.

This PR makes encoding of cookies collision-free.