### PR TITLE
Upgrade API version of the Prometheus and Grafana deployments

### DIFF
--- a/staging/kos/metrics/grafana/manifests/deployment.yaml
+++ b/staging/kos/metrics/grafana/manifests/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana

--- a/staging/kos/metrics/prometheus/manifests/deployment.yaml
+++ b/staging/kos/metrics/prometheus/manifests/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus


### PR DESCRIPTION
Upgrade the API version of the Prometheus and Grafana deployments to the stable version `apps/v1`. K8s v1.16 no longer supports beta versions, creation fails with:
> error: unable to recognize "metrics/grafana/manifests/deployment.yaml": no matches for kind "Deployment" in version "apps/v1beta2"