### PR TITLE
Tweak attachments throughput driver to support Poisson distribution

### DIFF
--- a/staging/kos/cmd/attachment-tput-driver/README.md
+++ b/staging/kos/cmd/attachment-tput-driver/README.md
@@ -296,7 +296,7 @@ The driver has two kinds of output: data files and `glog` logging.
 
 For the data files, the driver creates a directory under the current
 working directory.  The new directory's name is the same as the "run
-ID" (which is checked for safety).  The driver always writes three data
+ID" (which is checked for safety).  The driver writes at least three data
 files into that directory.  One holds the result of scraping the driver's
 Prometheus metrics.  The other two are the size distributions described
 above, in CSV format. Via a flag (disabled by default), users can make

--- a/staging/kos/cmd/attachment-tput-driver/README.md
+++ b/staging/kos/cmd/attachment-tput-driver/README.md
@@ -72,25 +72,39 @@ to stdout and those files.
 
 ## Timing and threading
 
-This driver aims to issue requests to create and delete
-NetworkAttachment objects steadily, at a given rate.  Once a
-NetworkAttachment becomes "ready" it is normally tested with ping, but
-this can optionally be disabled.
+The driver defines flags that let users customize the timing with which
+requests to create and delete NetworkAttachments are issued.  Currently
+operations on NetworkAttachments can either happen with a constant period
+or according to a Poisson process; in both cases a driver parameter lets
+users specify the rate of operations.  Once a NetworkAttachment becomes
+"ready" it is normally tested with ping, but this can optionally be
+disabled.
 
 This driver issues NetworkAttachment creation and deletion requests
 from a given number of threads.  The intended schedule of operations
-for each thread is fixed by the driver's parameters.  The parameters
-determine an intended time for each request to be issued.  If a thread
-is ready to issue a request before its time then the thread will sleep
-until the appointed time.  If a thread is not ready until after the
-appointed time then the request will be issued as soon as the thread
-can.
+for each thread is determined by the driver's parameters.  From the
+parameters, the driver determines an intended time for each request to
+be issued.  If a thread is ready to issue a request before its time then
+the thread will sleep until the appointed time.  If a thread is not ready
+until after the appointed time then the request will be issued as soon as
+the thread can.  Via a driver parameter (disabled by default), users can
+make the driver print a CSV file containing the intended timing of all
+operations for each thread. In such file, the time for each operation is
+not an absolute time, but an offset in seconds with respect to the instant
+at which operations on NetworkAttachments start.
 
-The timings of the threads are staggered.  That is, for a given
-operation rate R, the first thread aims to issue its requests at
-elapsed times `1/R`, `(1+num_threads)/R`, `(1+2*num_threads)/R`, ...;
-the second thread aims to issue its requests at elapsed times `2/R`,
-`(2+num_threads)/R`, `(2+2*num_threads)/R`, ...; and so on.
+The timings of the threads are staggered.  More precisely, if requests
+are issued with a constant period 1/R, the first thread aims to issue its
+requests at elapsed times `1/R`, `(1+num_threads)/R`, `(1+2*num_threads)/R`,
+...; the second thread aims to issue its requests at elapsed times `2/R`,
+`(2+num_threads)/R`, `(2+2*num_threads)/R`, ...; and so on.  Likewise, if
+requests are issued according to a Poisson process and the instants at which
+they must be issued are t<sub>0</sub>, t<sub>1</sub>,..., t<sub>m</sub>,
+the first thread aims to issue its requests at
+t<sub>0</sub>, t<sub>num_threads</sub>, t<sub>2\*num_threads</sub>,...;
+the second thread aims to issue its requests at
+t<sub>1</sub>, t<sub>1 + num_threads</sub>, t<sub>1 + 2\*num_threads</sub>,...;
+and so on.
 
 To minimize the number of non-full ping tests (see below), delays are
 sometimes introduced into the time series described above.  If, at the
@@ -282,10 +296,12 @@ The driver has two kinds of output: data files and `glog` logging.
 
 For the data files, the driver creates a directory under the current
 working directory.  The new directory's name is the same as the "run
-ID" (which is checked for safety).  The driver writes three data files
-into that directory.  One holds the result of scraping the driver's
-Prometheus metrics.  The other two are the size distributions
-described above, in CSV format.
+ID" (which is checked for safety).  The driver always writes three data
+files into that directory.  One holds the result of scraping the driver's
+Prometheus metrics.  The other two are the size distributions described
+above, in CSV format. Via a flag (disabled by default), users can make
+the driver write an additional file with the timing of creates and deletes
+on NetwotkAttachments, as described in section [Timing and Threading](#timing-and-threading)
 
 For logging the driver produces a great volume of log messages with
 the `glog` severity `INFO`, including every object creation and

--- a/staging/kos/cmd/attachment-tput-driver/main.go
+++ b/staging/kos/cmd/attachment-tput-driver/main.go
@@ -628,6 +628,8 @@ var kubeconfigPath = flag.String("kubeconfig", "", "Path to kubeconfig file")
 var numAttachments = flag.Int("num-attachments", 450, "Total number of attachments to create")
 var threads = flag.Uint64("threads", 1, "Total number of threads to use")
 var targetRate = flag.Float64("rate", 10, "Target aggregate rate, in ops/sec")
+var opsDistribution = flag.String("ops-distribution", steadyDistribution, "distribution of ops on attachments (\""+steadyDistribution+"\" or \""+poissonDistribution+"\")")
+var dumpOpsTimes = flag.Bool("dump-ops-times", false, "print file with timing of attachments operations")
 var subnetSizeFactor = flag.Float64("subnet-size-factor", 1.0, "size each subnet for this factor times the number of addresses needed")
 var onlyNode = flag.String("only-node", "", "node, if any, to be the exclusive location of attachments")
 var nodeLabelSelector = flag.String("node-label-selector", "", "label-selector, if any, to add to restriction role.kos.example.com/workload=true on which nodes get attachments")
@@ -670,7 +672,12 @@ func main() {
 		os.Exit(5)
 	}
 
-	glog.Warningf("Driver parameters: numNets=%d, topNetSize=%d, subnetSizeFactor=%g, lawPower=%g, lawBias=%d, justCount=%v, roundRobin=%v, pendingWait=%s, stopOnPingFail=%v, singleNetwork=%v, kubeconfigPath=%q, numAttachments=%d, threads=%d, targetRate=%g, waitAfterCreate=%s, waitAfterDelete=%s, onlyNode=%q, nodeLabelSelector=%q, runID=%q\n", *numNets, *topNetSize, *subnetSizeFactor, *lawPower, *lawBias, *justCount, *roundRobin, *pendingWait, *stopOnPingFail, *singleNetwork, *kubeconfigPath, *numAttachments, *threads, *targetRate, *waitAfterCreate, *waitAfterDelete, *onlyNode, *nodeLabelSelector, *runID)
+	if *opsDistribution != steadyDistribution && *opsDistribution != poissonDistribution {
+		glog.Errorf("Got unknown distribution \"%s\" for attachments ops, only \"%s\" and \"%s\" are supported.", *opsDistribution, steadyDistribution, poissonDistribution)
+		os.Exit(6)
+	}
+
+	glog.Warningf("Driver parameters: numNets=%d, topNetSize=%d, subnetSizeFactor=%g, lawPower=%g, lawBias=%d, justCount=%v, roundRobin=%v, pendingWait=%s, stopOnPingFail=%v, singleNetwork=%v, kubeconfigPath=%q, numAttachments=%d, threads=%d, targetRate=%g, attachmentsOpsDistribution=%s, waitAfterCreate=%s, waitAfterDelete=%s, onlyNode=%q, nodeLabelSelector=%q, runID=%q\n", *numNets, *topNetSize, *subnetSizeFactor, *lawPower, *lawBias, *justCount, *roundRobin, *pendingWait, *stopOnPingFail, *singleNetwork, *kubeconfigPath, *numAttachments, *threads, *targetRate, *opsDistribution, *waitAfterCreate, *waitAfterDelete, *onlyNode, *nodeLabelSelector, *runID)
 
 	vni0 := rand.Intn(32)*65536 + 1 // allow 64Ki VNIs in a run without overflowing the 21 bit limit
 	glog.Warningf("First VNI is %06x\n", vni0)
@@ -1031,14 +1038,23 @@ func main() {
 			glog.Warningf("Minimum nominal lifetime = %g sec\n", minLifetime)
 		}
 	}
+	threadIDtoAttsOpsSchedule := newOpsSchedule(*opsDistribution, opPeriod, uint64(*numAttachments*2), *threads)
+	if *dumpOpsTimes {
+		if err := printCSVOpsTimes(threadIDtoAttsOpsSchedule, *targetRate, *opsDistribution, outputDir); err != nil {
+			glog.Errorf("Error while dumping attachments ops times to file: %s", err)
+			os.Exit(8)
+		}
+	}
 	t0 := time.Now()
 	for i := uint64(0); i < *threads; i++ {
+		thdSched := threadIDtoAttsOpsSchedule[i]
+		delete(threadIDtoAttsOpsSchedule, i)
 		wg.Add(1)
 		go func(thd uint64) {
 			defer wg.Done()
 			numAttsToCreate := (uint64(*numAttachments) + *threads - 1 - thd) / (*threads)
 			slots := selectSlots(int(thd), int(*threads), vnAttachments)
-			RunThread(kClientset, stopCh, slots, nodeList.Items, nattNameFmt, *runID, t0, numAttsToCreate, thd+1, *threads, opPeriod, *roundRobin, *waitAfterCreate != 0)
+			RunThread(kClientset, stopCh, slots, nodeList.Items, nattNameFmt, *runID, thdSched, t0, numAttsToCreate, thd+1, *threads, *roundRobin, *waitAfterCreate != 0)
 		}(i)
 	}
 	wg.Wait()
@@ -1098,7 +1114,7 @@ func selectSlots(thd, numThreads int, from []VirtNetAttachment) []VirtNetAttachm
 	return assignedSlots
 }
 
-func RunThread(kClientset *kosclientset.Clientset, stopCh <-chan struct{}, work []VirtNetAttachment, nodes []k8sv1.Node, nattNameFmt, runID string, tbase time.Time, numAttsToCreate, thd, numThreads uint64, opPeriod float64, roundRobin, justCreate bool) {
+func RunThread(kClientset *kosclientset.Clientset, stopCh <-chan struct{}, work []VirtNetAttachment, nodes []k8sv1.Node, nattNameFmt, runID string, opsTimes threadOpsSchedule, tbase time.Time, numAttsToCreate, thd, numThreads uint64, roundRobin, justCreate bool) {
 	glog.Warningf("Thread start: thd=%d, numAttachments=%d, stride=%d\n", thd, numAttsToCreate, numThreads)
 	var iCreate, iDelete uint64
 	var workLen = uint64(len(work))
@@ -1107,7 +1123,7 @@ func RunThread(kClientset *kosclientset.Clientset, stopCh <-chan struct{}, work 
 	for iDelete < numAttsToCreate {
 		for {
 			xd := atomic.AddInt64(&xtraDelayI, 0)
-			dt := float64((iCreate+iDelete)*numThreads+thd) * opPeriod * float64(time.Second)
+			dt := opsTimes[iCreate+iDelete]
 			targt := tbase.Add(time.Duration(int64(dt) + xd))
 			now := time.Now()
 			if !targt.After(now) {
@@ -1296,4 +1312,34 @@ func withRetries(thunk func() bool, minWait, maxWait time.Duration, stopCh <-cha
 		}
 	}
 	return true
+}
+
+func printCSVOpsTimes(opsTimes map[uint64]threadOpsSchedule, rate float64, distribution, outputDir string) (err error) {
+	opsTimesFilename := filepath.Join(outputDir, "attachments-ops-times.csv")
+	var opsTimesCSVFile *os.File
+	opsTimesCSVFile, err = os.Create(opsTimesFilename)
+	if err != nil {
+		return
+	}
+	defer func() {
+		cerr := opsTimesCSVFile.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+	header := fmt.Sprintf("\"distribution: %s, rate: %g\"\n\"cell(i, j > 0) = dt in seconds at which ops j for thread i must take place wrt start of operations\"\n", distribution, rate)
+	if _, err = opsTimesCSVFile.Write([]byte(header)); err != nil {
+		return
+	}
+	for thd := 0; thd < len(opsTimes); thd++ {
+		thdTimes := opsTimes[uint64(thd)]
+		csvRow := fmt.Sprintf("thd %d", thd+1)
+		for _, dtNanos := range thdTimes {
+			csvRow = fmt.Sprintf("%s, %g", csvRow, float64(dtNanos)/float64(time.Second))
+		}
+		if _, err = opsTimesCSVFile.Write([]byte(csvRow + "\n")); err != nil {
+			return
+		}
+	}
+	return
 }

--- a/staging/kos/cmd/attachment-tput-driver/main.go
+++ b/staging/kos/cmd/attachment-tput-driver/main.go
@@ -632,7 +632,7 @@ var opsDistribution = flag.String("ops-distribution", steadyDistribution, "distr
 var dumpOpsTimes = flag.Bool("dump-ops-times", false, "print file with timing of attachments operations")
 var subnetSizeFactor = flag.Float64("subnet-size-factor", 1.0, "size each subnet for this factor times the number of addresses needed")
 var onlyNode = flag.String("only-node", "", "node, if any, to be the exclusive location of attachments")
-var nodeLabelSelector = flag.String("node-label-selector", "", "label-selector, if any, to add to restriction role.kos.example.com/workload=true on which nodes get attachments")
+var nodeLabelSelector = flag.String("node-label-selector", "role.kos.example.com/workload=true", "label-selector, if any, to restrict which nodes get attachments")
 
 var runID = flag.String("runid", "", "unique ID of this run (default is randomly generated)")
 
@@ -980,12 +980,8 @@ func main() {
 	vnAttachments = shuffle(vnAttachments)
 	vnAttachments = shuffle(vnAttachments)
 
-	fullNodeLabelSelector := "role.kos.example.com/workload=true"
-	if len(*nodeLabelSelector) > 0 {
-		fullNodeLabelSelector = fullNodeLabelSelector + "," + *nodeLabelSelector
-	}
 	nodeList, err := urClientset.CoreV1().Nodes().List(metav1.ListOptions{
-		LabelSelector: fullNodeLabelSelector})
+		LabelSelector: *nodeLabelSelector})
 	if err != nil {
 		glog.Errorf("Failed to get list of nodes: %s\n", err.Error())
 		os.Exit(30)

--- a/staging/kos/cmd/attachment-tput-driver/schedule.go
+++ b/staging/kos/cmd/attachment-tput-driver/schedule.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// A threadOpsSchedule is the schedule of operations on attachments for a single
+// thread. It consists of a list `dt0,..,dtn` of time intervals in nanoseconds.
+// The ith operation that the thread must perform must happen at `t0 + dti`,
+// where t0 is an arbitrary start time for operations on attachments.
+// "Arbitrary start time" means that the start time is not hardcoded in the
+// schedule, and it is up to the schedule user to provide it. This is done
+// because computing a schedule might take time; if the schedule was dependent
+// on a t0, by the time it was computed t0 + dti might already have elapsed.
+// Compute the schedule first, and then pick a t0.
+type threadOpsSchedule []int64
+
+// Supported distributions of the operations on attachments.
+const (
+	steadyDistribution  = "steady"
+	poissonDistribution = "poisson"
+)
+
+// newOpsSchedule returns a schedule for the operations on attachments. The
+// returned schedule satisfies the `opsDistribution` and `opsPeriod` parameters.
+func newOpsSchedule(opsDistribution string, opsPeriod float64, totalOps, numThreads uint64) map[uint64]threadOpsSchedule {
+	threadIDToOpsSchedule := make(map[uint64]threadOpsSchedule, numThreads)
+
+	// For each operation on attachments, compute a dt such that the operation
+	// should take place at `t0 + dt` where t0 is the arbitrary start time for
+	// operations managed outside of this function.
+	var dtNanos int64
+	for i := uint64(0); i < totalOps; i++ {
+		if opsDistribution == poissonDistribution {
+			// The time between an op and the next one is given by the
+			// exponential distribution with rate `1/opsPeriod`.
+			dtNanos += int64(float64(time.Second) * (opsPeriod * rand.ExpFloat64()))
+		} else {
+			// The ops on attachments happen with a constant period.
+			dtNanos += int64(float64(time.Second) * opsPeriod)
+		}
+		if dtNanos < 0 {
+			// Overflow! This should never happen, because at every iteration
+			// dtNanos is less than or (approximately) equal to the time of the
+			// whole throughput driver run, and an int64 is able to accommodate
+			// runs that last longer than 20 years. We check anyway for safety.
+			glog.Error("Encountered an overflow while computing timing of operations on attachments; lower number of attachments to create or increase ops rate to resolve.")
+			os.Exit(100)
+		}
+		thd := i % numThreads
+		if i < numThreads {
+			threadIDToOpsSchedule[thd] = make(threadOpsSchedule, 0, 1+totalOps/numThreads)
+		}
+		threadIDToOpsSchedule[thd] = append(threadIDToOpsSchedule[thd], dtNanos)
+	}
+
+	//! The memory footprint of the schedule is theta(N) where N is the total
+	// number of operations (create/delete) that must be performed on the
+	// attachments. We are interested in large-scale ==> N can be large, this
+	// can be a problem. Or not, our current base machine in the test cluster
+	// has 32 GiB; if we were to create a total of 120 millions of attachments
+	// the schedule would roughly take a little bit more than 2.6 GiB.
+	return threadIDToOpsSchedule
+}

--- a/staging/kos/cmd/attachment-tput-driver/schedule.go
+++ b/staging/kos/cmd/attachment-tput-driver/schedule.go
@@ -24,16 +24,22 @@ import (
 	"github.com/golang/glog"
 )
 
-// A threadOpsSchedule is the schedule of operations on attachments for a single
-// thread. It consists of a list `dt0,..,dtn` of time intervals in nanoseconds.
-// The ith operation that the thread must perform must happen at `t0 + dti`,
-// where t0 is an arbitrary start time for operations on attachments.
-// "Arbitrary start time" means that the start time is not hardcoded in the
-// schedule, and it is up to the schedule user to provide it. This is done
-// because computing a schedule might take time; if the schedule was dependent
-// on a t0, by the time it was computed t0 + dti might already have elapsed.
-// Compute the schedule first, and then pick a t0.
-type threadOpsSchedule []int64
+// OpsSchedule is the schedule of operations on attachments. It consists of a
+// list `dt0,..,dtn` of time intervals in nanoseconds. The ith operation that
+// must be performed must happen at `t0 + dti`, where t0 is an arbitrary start
+// time for operations on attachments. "Arbitrary start time" means that the
+// start time is not hardcoded in the schedule, and it is up to the schedule
+// user to provide it. This is done because computing a schedule might take
+// time; if the schedule was dependent on a t0, by the time it was computed
+// `t0 + dti` might already have elapsed. Compute the schedule first, and then
+// pick a t0.
+//
+// The memory footprint of OpsSchedule is theta(N) where N is the total number
+// of operations (create/delete) that must be performed on the attachments. We
+// are interested in large-scale ==> N can be large, this can be a problem.
+// Or not: if a total of 120 millions of attachments were created by the driver,
+// the schedule would roughly take a little bit more than 2.6 GiB.
+type OpsSchedule []time.Duration
 
 // Supported distributions of the operations on attachments.
 const (
@@ -43,23 +49,30 @@ const (
 
 // newOpsSchedule returns a schedule for the operations on attachments. The
 // returned schedule satisfies the `opsDistribution` and `opsPeriod` parameters.
-func newOpsSchedule(opsDistribution string, opsPeriod float64, totalOps, numThreads uint64) map[uint64]threadOpsSchedule {
-	threadIDToOpsSchedule := make(map[uint64]threadOpsSchedule, numThreads)
+func newOpsSchedule(opsDistribution string, opsPeriodSecs float64, totalOps uint64) OpsSchedule {
+	opsSchedule := make(OpsSchedule, totalOps, totalOps)
 
 	// For each operation on attachments, compute a dt such that the operation
 	// should take place at `t0 + dt` where t0 is the arbitrary start time for
 	// operations managed outside of this function.
-	var dtNanos int64
+	var dtFromStart time.Duration
 	for i := uint64(0); i < totalOps; i++ {
 		if opsDistribution == poissonDistribution {
-			// The time between an op and the next one is given by the
-			// exponential distribution with rate `1/opsPeriod`.
-			dtNanos += int64(float64(time.Second) * (opsPeriod * rand.ExpFloat64()))
+			// The time in secs between an op and the next one is given by the
+			// exponential distribution with rate `1/opsPeriodSecs`.
+			dtFromPreviousOpSecs := opsPeriodSecs * rand.ExpFloat64()
+			if dtFromPreviousOpSecs > 1000 {
+				// Truncate dt from previous op because we only care about high
+				// rates and we want to minimize the risk of overflowing
+				// dtFromPreviousOpNanos.
+				dtFromPreviousOpSecs = 1000
+			}
+			dtFromStart += time.Duration(float64(time.Second) * dtFromPreviousOpSecs)
 		} else {
 			// The ops on attachments happen with a constant period.
-			dtNanos += int64(float64(time.Second) * opsPeriod)
+			dtFromStart += time.Duration(float64(time.Second) * opsPeriodSecs)
 		}
-		if dtNanos < 0 {
+		if dtFromStart < 0 {
 			// Overflow! This should never happen, because at every iteration
 			// dtNanos is less than or (approximately) equal to the time of the
 			// whole throughput driver run, and an int64 is able to accommodate
@@ -67,18 +80,8 @@ func newOpsSchedule(opsDistribution string, opsPeriod float64, totalOps, numThre
 			glog.Error("Encountered an overflow while computing timing of operations on attachments; lower number of attachments to create or increase ops rate to resolve.")
 			os.Exit(100)
 		}
-		thd := i % numThreads
-		if i < numThreads {
-			threadIDToOpsSchedule[thd] = make(threadOpsSchedule, 0, 1+totalOps/numThreads)
-		}
-		threadIDToOpsSchedule[thd] = append(threadIDToOpsSchedule[thd], dtNanos)
+		opsSchedule[i] = dtFromStart
 	}
 
-	//! The memory footprint of the schedule is theta(N) where N is the total
-	// number of operations (create/delete) that must be performed on the
-	// attachments. We are interested in large-scale ==> N can be large, this
-	// can be a problem. Or not, our current base machine in the test cluster
-	// has 32 GiB; if we were to create a total of 120 millions of attachments
-	// the schedule would roughly take a little bit more than 2.6 GiB.
-	return threadIDToOpsSchedule
+	return opsSchedule
 }


### PR DESCRIPTION
Tweak the attachments throughput test driver by adding the ability to issue requests to create and delete NetworkAttachments following a Poisson distribution.
Before this PR requests can only be issued with a constant period.