### PR TITLE
Fix Test Driver

### DIFF
--- a/staging/kos/cmd/attachment-tput-driver/README.md
+++ b/staging/kos/cmd/attachment-tput-driver/README.md
@@ -75,10 +75,13 @@ to stdout and those files.
 The driver defines flags that let users customize the timing with which
 requests to create and delete NetworkAttachments are issued.  Currently
 operations on NetworkAttachments can either happen with a constant period
-or according to a Poisson process; in both cases a driver parameter lets
-users specify the rate of operations.  Once a NetworkAttachment becomes
-"ready" it is normally tested with ping, but this can optionally be
-disabled.
+or according to an approximated Poisson process; in both cases a driver
+parameter lets users specify the average rate of operations.  The Poisson
+process is approximated because the interval between two successive arrivals
+is given by an exponential distribution truncated to `1000/lambda secs`
+instead of a real exponential distribution.  Once a NetworkAttachment
+becomes "ready" it is normally tested with ping, but this can optionally
+be disabled.
 
 This driver issues NetworkAttachment creation and deletion requests
 from a given number of threads.  The intended schedule of operations

--- a/staging/kos/cmd/attachment-tput-driver/schedule.go
+++ b/staging/kos/cmd/attachment-tput-driver/schedule.go
@@ -58,16 +58,14 @@ func newOpsSchedule(opsDistribution string, opsPeriodSecs float64, totalOps uint
 	var dtFromStart time.Duration
 	for i := uint64(0); i < totalOps; i++ {
 		if opsDistribution == poissonDistribution {
+			expDistRate1 := rand.ExpFloat64()
+			if expDistRate1 > 1000 {
+				// Truncate to avoid impractically large intervals between ops.
+				expDistRate1 = 1000
+			}
 			// The time in secs between an op and the next one is given by the
 			// exponential distribution with rate `1/opsPeriodSecs`.
-			dtFromPreviousOpSecs := opsPeriodSecs * rand.ExpFloat64()
-			if dtFromPreviousOpSecs > 1000 {
-				// Truncate dt from previous op because we only care about high
-				// rates and we want to minimize the risk of overflowing
-				// dtFromPreviousOpNanos.
-				dtFromPreviousOpSecs = 1000
-			}
-			dtFromStart += time.Duration(float64(time.Second) * dtFromPreviousOpSecs)
+			dtFromStart += time.Duration(float64(time.Second) * opsPeriodSecs * expDistRate1)
 		} else {
 			// The ops on attachments happen with a constant period.
 			dtFromStart += time.Duration(float64(time.Second) * opsPeriodSecs)


### PR DESCRIPTION
Fix bug in test driver that caused slice index out of bound panics. In a nutshell, the driver assumed a constant stride (in term of number of ops including those of other threads) between successive ops of the same thread. This is not true because for some parameters some threads perform more operations than others, as a result the stride between the last ops of some threads is smaller than the stride between previous ops.

Also, add suggestions in review of https://github.com/MikeSpreitzer/kube-examples/pull/89