### PR TITLE
Debugging for "RTNETLINK answers: Invalid argument"

### DIFF
--- a/staging/kos/cmd/attachment-tput-driver/main.go
+++ b/staging/kos/cmd/attachment-tput-driver/main.go
@@ -406,8 +406,11 @@ func (slot *Slot) observeState(virtNet *VirtNet, slotIndex int, natt *netv1a1.Ne
 			slot.testedTime = now
 			cr := natt.Status.PostCreateExecReport
 			slot.testES = cr.ExitStatus
-			if cr.ExitStatus != 0 {
-				glog.Infof("Non-zero test exit status: attachment=%s/%s, VNI=%06x, subnet=%s, RV=%s, node=%s, IPv4=%s, MAC=%s, testES=%d, StartTime=%s, StopTime=%s, StdOut=%q, StdErr=%q\n", theKubeNS, slot.currentAttachmentName, virtNet.ID, natt.Spec.Subnet, natt.ResourceVersion, natt.Spec.Node, natt.Status.IPv4, natt.Status.MACAddress, cr.ExitStatus, cr.StartTime, cr.StopTime, cr.StdOut, cr.StdErr)
+			if strings.Contains(cr.StdOut, "Invalid") || strings.Contains(cr.StdErr, "Invalid") {
+				slot.testES = slot.testES + 64
+			}
+			if slot.testES != 0 {
+				glog.Infof("Non-zero test exit status: attachment=%s/%s, VNI=%06x, subnet=%s, RV=%s, node=%s, IPv4=%s, MAC=%s, testES=%d, StartTime=%s, StopTime=%s, StdOut=%q, StdErr=%q\n", theKubeNS, slot.currentAttachmentName, virtNet.ID, natt.Spec.Subnet, natt.ResourceVersion, natt.Spec.Node, natt.Status.IPv4, natt.Status.MACAddress, slot.testES, cr.StartTime, cr.StopTime, cr.StdOut, cr.StdErr)
 			}
 			if slot.testES == 0 {
 				cd.NoteTested(slotIndex)

--- a/staging/kos/cmd/attachment-tput-driver/test-scripts/TestByPing
+++ b/staging/kos/cmd/attachment-tput-driver/test-scripts/TestByPing
@@ -13,17 +13,19 @@ peer_name=$6
 
 {
 	ip link show $ifc_name || exit 2
-	echo ===Add===
+	echo ===NetNS===
 	ip netns add $netns_name
+	sleep 1
 	echo ===Move===
 	ip link set $ifc_name netns $netns_name
+	sleep 1
 	echo ===Config===
 	ip netns exec $netns_name ip link set $ifc_name up
 	ip netns exec $netns_name ip addr add $ifc_ip dev $ifc_name
 	ip netns exec $netns_name ip route add default dev $ifc_name
-	echo ===Addr===
+	echo ===Addrs===
 	ip netns exec $netns_name ip addr
-	echo ===Route===
+	echo ===Routes===
 	ip netns exec $netns_name ip route
 	if [ -n "$peer_ip" ]; then
 		for (( i=0; i < $count; i++ )) ; do

--- a/staging/kos/cmd/attachment-tput-driver/test-scripts/TestByPing
+++ b/staging/kos/cmd/attachment-tput-driver/test-scripts/TestByPing
@@ -11,19 +11,25 @@ peer_ip=$4
 count=${5:-5}
 peer_name=$6
 
-ip link show $ifc_name || exit 2
-ip netns add $netns_name
-ip link set $ifc_name netns $netns_name
-ip netns exec $netns_name ip link set $ifc_name up
-ip netns exec $netns_name ip addr add $ifc_ip dev $ifc_name
-ip netns exec $netns_name ip route add default dev $ifc_name
-echo " - "
-ip netns exec $netns_name ip addr
-ip netns exec $netns_name ip route
-if [ -n "$peer_ip" ]; then
-	for (( i=0; i < $count; i++ )) ; do
-		echo $i: $(date +%M:%S)
-		ip netns exec $netns_name ping -W 15 -c 1 $peer_ip && echo done: $(date +%M:%S) && exit 0
-	done
-	exit 3
-fi
+{
+	ip link show $ifc_name || exit 2
+	echo ===Add===
+	ip netns add $netns_name
+	echo ===Move===
+	ip link set $ifc_name netns $netns_name
+	echo ===Config===
+	ip netns exec $netns_name ip link set $ifc_name up
+	ip netns exec $netns_name ip addr add $ifc_ip dev $ifc_name
+	ip netns exec $netns_name ip route add default dev $ifc_name
+	echo ===Addr===
+	ip netns exec $netns_name ip addr
+	echo ===Route===
+	ip netns exec $netns_name ip route
+	if [ -n "$peer_ip" ]; then
+		for (( i=0; i < $count; i++ )) ; do
+			echo $i: $(date +%M:%S)
+			ip netns exec $netns_name ping -W 15 -c 1 $peer_ip && echo done: $(date +%M:%S) && exit 0
+		done
+		exit 3
+	fi
+} 2>&1


### PR DESCRIPTION
I found long ping test latencies, and stderr containing many copies of "RTNETLINK answers: Invalid argument" (and nothing else).  So I could not tell what was provoking those complaints.  So I made the TestByPing script send stderr to stdout.  Still got puzzling results, the interleaving of stderr into stdout is probably not perfect.  Added a couple of `sleep 1` to TestByPing.  Still varying results.  But in many cases the complaint appeared right after the `ip netns add` command was executed (according to the interleaving).

Also made the attachment-tput-driver count it as a failure if stdout or stderr contains "Invalid", to get stats on how much this is happening.