### PR TITLE
Fix histogram for latency from NetworkAttachment creation to IPLock creation

### DIFF
--- a/staging/kos/pkg/apis/network/types.go
+++ b/staging/kos/pkg/apis/network/types.go
@@ -491,6 +491,9 @@ type IPLockSpec struct {
 	SubnetName string
 }
 
+// The only ExtendedObjectMeta section for an IPLock.
+const IPLockSectionWholeObj = "whole_object"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -499,6 +502,10 @@ type IPLock struct {
 
 	// +optional
 	metav1.ObjectMeta
+
+	// `extendedMetadata` adds non-standard object metadata.
+	// +optional
+	ExtendedObjectMeta
 
 	Spec IPLockSpec
 }

--- a/staging/kos/pkg/apis/network/v1alpha1/types.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/types.go
@@ -491,6 +491,9 @@ type IPLockSpec struct {
 	SubnetName string `json:"subnetName" protobuf:"bytes,1,name=subnetName"`
 }
 
+// The only ExtendedObjectMeta section for an IPLock.
+const IPLockSectionWholeObj = "whole_object"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -500,7 +503,11 @@ type IPLock struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	Spec IPLockSpec `json:"spec" protobuf:"bytes,2,name=spec"`
+	// `extendedMetadata` adds non-standard object metadata.
+	// +optional
+	ExtendedObjectMeta `json:"extendedMetadata,omitempty" protobuf:"bytes,2,opt,name=extendedMetadata"`
+
+	Spec IPLockSpec `json:"spec" protobuf:"bytes,3,name=spec"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
@@ -250,6 +250,9 @@ func Convert_network_ExtendedObjectMeta_To_v1alpha1_ExtendedObjectMeta(in *netwo
 
 func autoConvert_v1alpha1_IPLock_To_network_IPLock(in *IPLock, out *network.IPLock, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
+	if err := Convert_v1alpha1_ExtendedObjectMeta_To_network_ExtendedObjectMeta(&in.ExtendedObjectMeta, &out.ExtendedObjectMeta, s); err != nil {
+		return err
+	}
 	if err := Convert_v1alpha1_IPLockSpec_To_network_IPLockSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
@@ -263,6 +266,9 @@ func Convert_v1alpha1_IPLock_To_network_IPLock(in *IPLock, out *network.IPLock, 
 
 func autoConvert_network_IPLock_To_v1alpha1_IPLock(in *network.IPLock, out *IPLock, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
+	if err := Convert_network_ExtendedObjectMeta_To_v1alpha1_ExtendedObjectMeta(&in.ExtendedObjectMeta, &out.ExtendedObjectMeta, s); err != nil {
+		return err
+	}
 	if err := Convert_network_IPLockSpec_To_v1alpha1_IPLockSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}

--- a/staging/kos/pkg/apis/network/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/zz_generated.deepcopy.go
@@ -73,6 +73,7 @@ func (in *IPLock) DeepCopyInto(out *IPLock) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.ExtendedObjectMeta.DeepCopyInto(&out.ExtendedObjectMeta)
 	out.Spec = in.Spec
 	return
 }

--- a/staging/kos/pkg/apis/network/zz_generated.deepcopy.go
+++ b/staging/kos/pkg/apis/network/zz_generated.deepcopy.go
@@ -73,6 +73,7 @@ func (in *IPLock) DeepCopyInto(out *IPLock) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	in.ExtendedObjectMeta.DeepCopyInto(&out.ExtendedObjectMeta)
 	out.Spec = in.Spec
 	return
 }

--- a/staging/kos/pkg/controllers/ipam/ipam.go
+++ b/staging/kos/pkg/controllers/ipam/ipam.go
@@ -730,7 +730,7 @@ func (ctlr *IPAMController) pickAndLockAddress(ns, name string, att *netv1a1.Net
 			ctlr.eventRecorder.Eventf(att, k8scorev1api.EventTypeNormal, "AddressAssigned", "Assigned IPv4 address %s", ipForStatus)
 			klog.V(4).Infof("Locked IP address %s for %s/%s=%s, lockName=%s, lockUID=%s, Status.IPv4 was %q", ipForStatus, ns, name, string(att.UID), lockName, string(ipl2.UID), att.Status.IPv4)
 			if len(att.Status.IPv4) == 0 {
-				ctlr.attachmentCreateToLockHistogram.Observe(ipl2.CreationTimestamp.Sub(att.CreationTimestamp.Time).Seconds())
+				ctlr.attachmentCreateToLockHistogram.Observe(ipl2.Writes.GetServerWriteTime(netv1a1.IPLockSectionWholeObj).Sub(att.Writes.GetServerWriteTime(netv1a1.NASectionSpec)).Seconds())
 			}
 			break
 		} else if k8serrors.IsAlreadyExists(err) {

--- a/staging/kos/pkg/controllers/ipam/ipam.go
+++ b/staging/kos/pkg/controllers/ipam/ipam.go
@@ -136,7 +136,7 @@ func NewController(netIfc kosclientv1a1.NetworkV1alpha1Interface,
 			Subsystem: metricsSubsystem,
 			Name:      "attachment_create_to_lock_latency_seconds",
 			Help:      "Latency from Attachment CreationTimestamp to IPLock CreationTimestamp, in seconds",
-			Buckets:   []float64{-1, 0, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 64},
+			Buckets:   []float64{-1, 0, 0.125, 0.25, 0.5, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 64},
 		})
 
 	lockOpHistograms := prometheus.NewHistogramVec(

--- a/staging/kos/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/kos/pkg/generated/openapi/zz_generated.openapi.go
@@ -2522,6 +2522,12 @@ func schema_pkg_apis_network_v1alpha1_IPLock(ref common.ReferenceCallback) commo
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
+					"extendedMetadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "`extendedMetadata` adds non-standard object metadata.",
+							Ref:         ref("k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.ExtendedObjectMeta"),
+						},
+					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.IPLockSpec"),
@@ -2532,7 +2538,7 @@ func schema_pkg_apis_network_v1alpha1_IPLock(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.IPLockSpec"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta", "k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.ExtendedObjectMeta", "k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.IPLockSpec"},
 	}
 }
 

--- a/staging/kos/pkg/registry/network/iplock/strategy.go
+++ b/staging/kos/pkg/registry/network/iplock/strategy.go
@@ -77,6 +77,9 @@ func (iplockStrategy) NamespaceScoped() bool {
 }
 
 func (iplockStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	ipLock := obj.(*network.IPLock)
+	ipLock.ExtendedObjectMeta = network.ExtendedObjectMeta{}
+	ipLock.Writes = ipLock.Writes.SetWrite(network.IPLockSectionWholeObj, network.Now())
 }
 
 func (iplockStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {


### PR DESCRIPTION
The Grafana dashboard for the 99th %ile of the latency in seconds from NetworkAttachment creation to creation of the NetworkAttachment's IPLock reports values that are higher than the 99th %ile of the latency from NetworkAttachment creation to the update that writes the NetworkAttachment's IP address into the NetworkAttachment's status.
This does not make sense as the status update takes place after creation of the IPLock.

This PR fixes the problem by harmonizing the buckets of the two histograms and extending usage of extended metadata write times (which have subsecond resolution, unlike the previously used standard metadata timestamps) to the histogram for IPLocks as well.