### PR TITLE
[WIP] Upgrade Ubuntu container images to 18.04 LTS

### DIFF
--- a/staging/kos/images/connection-agent/Dockerfile
+++ b/staging/kos/images/connection-agent/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y \
     iproute2 \
     iputils-ping \

--- a/staging/kos/images/controller-manager/Dockerfile
+++ b/staging/kos/images/controller-manager/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 COPY controller-manager /
 ENTRYPOINT ["/controller-manager"]

--- a/staging/kos/images/network-apiserver/Dockerfile
+++ b/staging/kos/images/network-apiserver/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 COPY network-apiserver /
 ENTRYPOINT ["/network-apiserver"]


### PR DESCRIPTION
Upgrade Ubuntu container images of KOS components from 16.04 to 18.04 LTS.

This also implicitly upgrades iproute2 from 4.3.0 to 4.15.0, which makes the "RTNETLINK Answer: Invalid Argument" spurious error disappear.

WIP because I haven't removed all the "scaffolding" that was added to TestByPing (such as the sleeps and the prints) to troubleshoot the RTNETLINK error message.

We might also want to use batching of "ip netns" commands for performance. 