### PR TITLE
Remove sleep commands from TestByPing

### DIFF
--- a/staging/kos/cmd/attachment-tput-driver/test-scripts/TestByPing
+++ b/staging/kos/cmd/attachment-tput-driver/test-scripts/TestByPing
@@ -14,10 +14,8 @@ peer_name=$6
 ip link show $ifc_name || exit 2
 echo "===$(date +%M:%S): NetNS===" >&2
 ip netns add $netns_name
-sleep 1
 echo "===$(date +%M:%S): Move===" >&2
 ip link set $ifc_name netns $netns_name
-sleep 1
 echo "===$(date +%M:%S): Config===" >&2
 ip netns exec $netns_name ip link set $ifc_name up
 ip netns exec $netns_name ip addr add $ifc_ip dev $ifc_name


### PR DESCRIPTION
They were just there to help debug the "RNETLINK answers: Invalid
argument" problem.