### PR TITLE
Introduce status subresources

### DIFF
--- a/staging/kos/deploy/main/30-role-ca.yaml
+++ b/staging/kos/deploy/main/30-role-ca.yaml
@@ -7,16 +7,18 @@ rules:
   - network.example.com
   resources:
   - networkattachments
-  - networkattachments/status
   verbs:
   - list
   - watch
+- apiGroups:
+  - network.example.com
+  resources:
+  - networkattachments/status
+  verbs:
   - update
-  - patch
 - apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
-  - patch

--- a/staging/kos/deploy/main/30-role-ipam.yaml
+++ b/staging/kos/deploy/main/30-role-ipam.yaml
@@ -7,6 +7,7 @@ rules:
   - network.example.com
   resources:
   - subnets
+  - networkattachments
   verbs:
   - get
   - list
@@ -14,14 +15,22 @@ rules:
 - apiGroups:
   - network.example.com
   resources:
-  - networkattachments
+  - networkattachments/status
+  verbs:
+  - update
+- apiGroups:
+  - network.example.com
+  resources:
   - iplocks
   verbs:
-  - "*"
+  - create
+  - get
+  - list
+  - watch
+  - delete
 - apiGroups:
   - ""
   resources:
   - events
   verbs:
   - create
-  - patch

--- a/staging/kos/deploy/main/30-role-sv.yaml
+++ b/staging/kos/deploy/main/30-role-sv.yaml
@@ -7,10 +7,14 @@ rules:
   - network.example.com
   resources:
   - subnets
-  - subnets/status
   verbs:
   - list
   - watch
+- apiGroups:
+  - network.example.com
+  resources:
+  - subnets/status
+  verbs:
   - update
 - apiGroups:
   - ""
@@ -18,4 +22,3 @@ rules:
   - events
   verbs:
   - create
-  - patch

--- a/staging/kos/pkg/controllers/ipam/ipam.go
+++ b/staging/kos/pkg/controllers/ipam/ipam.go
@@ -148,10 +148,8 @@ func NewController(netIfc kosclientv1a1.NetworkV1alpha1Interface,
 			Buckets:   []float64{-0.125, 0, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64},
 		},
 		[]string{"op", "err"})
-	errValT, errValF := FormatErrVal(true), FormatErrVal(false)
-	lockOpHistograms.With(prometheus.Labels{"op": opCreate, "err": errValT})
+	errValF := FmtErrBool(false)
 	lockOpHistograms.With(prometheus.Labels{"op": opCreate, "err": errValF})
-	lockOpHistograms.With(prometheus.Labels{"op": opDelete, "err": errValT})
 	lockOpHistograms.With(prometheus.Labels{"op": opDelete, "err": errValF})
 
 	attachmentCreateToAddressHistogram := prometheus.NewHistogram(
@@ -172,10 +170,7 @@ func NewController(netIfc kosclientv1a1.NetworkV1alpha1Interface,
 			Buckets:   []float64{-0.125, 0, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64},
 		},
 		[]string{"statusErr", "err"})
-	attachmentUpdateHistograms.With(prometheus.Labels{"statusErr": errValT, "err": errValT})
 	attachmentUpdateHistograms.With(prometheus.Labels{"statusErr": errValF, "err": errValF})
-	attachmentUpdateHistograms.With(prometheus.Labels{"statusErr": errValT, "err": errValF})
-	attachmentUpdateHistograms.With(prometheus.Labels{"statusErr": errValF, "err": errValT})
 
 	anticipationUsedHistogram := prometheus.NewHistogram(
 		prometheus.HistogramOpts{
@@ -675,7 +670,7 @@ func (ctlr *IPAMController) deleteIPLockObject(parsed ParsedLock) error {
 	tBefore := time.Now()
 	err := lockOps.Delete(parsed.name, &delOpts)
 	tAfter := time.Now()
-	ctlr.lockOpHistograms.With(prometheus.Labels{"op": opDelete, "err": FormatErrVal(err != nil && !k8serrors.IsNotFound(err))}).Observe(tAfter.Sub(tBefore).Seconds())
+	ctlr.lockOpHistograms.With(prometheus.Labels{"op": opDelete, "err": FmtErrBool(err != nil && !k8serrors.IsNotFound(err))}).Observe(tAfter.Sub(tBefore).Seconds())
 	if err == nil {
 		klog.V(4).Infof("Deleted IPLock %s/%s=%s", parsed.ns, parsed.name, string(parsed.UID))
 	} else if k8serrors.IsNotFound(err) {
@@ -725,7 +720,7 @@ func (ctlr *IPAMController) pickAndLockAddress(ns, name string, att *netv1a1.Net
 		tBefore := time.Now()
 		ipl2, err = lockOps.Create(ipl)
 		tAfter := time.Now()
-		ctlr.lockOpHistograms.With(prometheus.Labels{"op": opCreate, "err": FormatErrVal(err != nil)}).Observe(tAfter.Sub(tBefore).Seconds())
+		ctlr.lockOpHistograms.With(prometheus.Labels{"op": opCreate, "err": FmtErrBool(err != nil)}).Observe(tAfter.Sub(tBefore).Seconds())
 		if err == nil {
 			ctlr.eventRecorder.Eventf(att, k8scorev1api.EventTypeNormal, "AddressAssigned", "Assigned IPv4 address %s", ipForStatus)
 			klog.V(4).Infof("Locked IP address %s for %s/%s=%s, lockName=%s, lockUID=%s, Status.IPv4 was %q", ipForStatus, ns, name, string(att.UID), lockName, string(ipl2.UID), att.Status.IPv4)
@@ -780,6 +775,11 @@ func (ctlr *IPAMController) pickAndLockAddress(ns, name string, att *netv1a1.Net
 }
 
 func (ctlr *IPAMController) updateNAStatus(ns, name string, att *netv1a1.NetworkAttachment, nadat *NetworkAttachmentData, statusErrs []string, subnetUID k8stypes.UID, lockForStatus ParsedLock, ipForStatus gonet.IP) error {
+	test, _ := ctlr.netattLister.NetworkAttachments(ns).Get(name)
+	if test == nil { // It has been deleted, don't bother
+		klog.V(4).Infof("Did not attempt to update status of deleted NetworkAttachment %s/%s", ns, name)
+		return nil
+	}
 	att2 := att.DeepCopy()
 	att2.Status.Errors.IPAM = statusErrs
 	att2.Status.LockUID = string(lockForStatus.UID)
@@ -791,16 +791,16 @@ func (ctlr *IPAMController) updateNAStatus(ns, name string, att *netv1a1.Network
 	}
 	attachmentOps := ctlr.netIfc.NetworkAttachments(ns)
 	tBefore := time.Now()
-	att3, err := attachmentOps.Update(att2)
+	att3, err := attachmentOps.UpdateStatus(att2)
 	tAfter := time.Now()
-	ctlr.attachmentUpdateHistograms.With(prometheus.Labels{"statusErr": FormatErrVal(len(statusErrs) > 0), "err": FormatErrVal(err != nil)}).Observe(tAfter.Sub(tBefore).Seconds())
+	ctlr.attachmentUpdateHistograms.With(prometheus.Labels{"statusErr": FmtErrBool(len(statusErrs) > 0), "err": SummarizeErr(err)}).Observe(tAfter.Sub(tBefore).Seconds())
 	if err == nil {
 		deltaS := att3.Writes.GetServerWriteTime(netv1a1.NASectionAddr).Sub(att.Writes.GetServerWriteTime(netv1a1.NASectionSpec)).Seconds()
 		ctlr.attachmentCreateToAddressHistogram.Observe(deltaS)
 		if len(statusErrs) > 0 {
-			klog.V(4).Infof("Recorded errors %v in status of %s/%s, old ResourceVersion=%s, new ResourceVersion=%s", statusErrs, ns, name, att.ResourceVersion, att3.ResourceVersion)
+			klog.V(4).Infof("Recorded errors %v in status of %s/%s, subnetUID=%s, old ResourceVersion=%s, new ResourceVersion=%s, deltaS=%v", statusErrs, ns, name, subnetUID, att.ResourceVersion, att3.ResourceVersion, deltaS)
 		} else {
-			klog.V(4).Infof("Recorded locked address %s in status of %s/%s, old ResourceVersion=%s, new ResourceVersion=%s, subnetUID=%s", ipForStatus, ns, name, att.ResourceVersion, att3.ResourceVersion, subnetUID)
+			klog.V(4).Infof("Recorded locked address %s in status of %s/%s, subnetUID=%s, old ResourceVersion=%s, new ResourceVersion=%s, deltaS=%v", ipForStatus, ns, name, subnetUID, att.ResourceVersion, att3.ResourceVersion, deltaS)
 			nadat.anticipatingResourceVersion = att.ResourceVersion
 			nadat.anticipatedResourceVersion = att3.ResourceVersion
 			nadat.anticipationSubnetUID = subnetUID
@@ -814,7 +814,7 @@ func (ctlr *IPAMController) updateNAStatus(ns, name string, att *netv1a1.Network
 	} else {
 		errMsg = fmt.Sprintf("%s allocated address %s", errMsg, ipForStatus)
 	}
-	if k8serrors.IsNotFound(err) {
+	if IsNotFound(err) {
 		klog.V(4).Infof("%s: NetworkAttachment was deleted.", errMsg)
 		return nil
 	}
@@ -1029,9 +1029,36 @@ func (list ParsedLockList) RemFunc(elt ParsedLock) (sans ParsedLockList, diff bo
 	return list, false
 }
 
-func FormatErrVal(err bool) string {
+func FmtErrBool(err bool) string {
 	if err {
 		return "err"
 	}
 	return "ok"
 }
+
+func SummarizeErr(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	if IsNotFound(err) {
+		return ErrValNF
+	}
+	return "err"
+}
+
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if k8serrors.IsNotFound(err) {
+		return true
+	}
+	// https://github.com/kubernetes/kubernetes/issues/89985
+	msg := err.Error()
+	if strings.Contains(msg, "Precondition failed: UID in precondition") && strings.HasSuffix(strings.TrimSpace(msg), ", UID in object meta:") {
+		return true
+	}
+	return false
+}
+
+const ErrValNF = "nf"

--- a/staging/kos/pkg/controllers/subnet/validator.go
+++ b/staging/kos/pkg/controllers/subnet/validator.go
@@ -585,7 +585,7 @@ func (v *Validator) updateSubnetValidity(s1 *netv1a1.Subnet, validationErrors []
 	s2.Status.Errors = validationErrors
 
 	tBefore := time.Now()
-	s3, err := v.netIfc.Subnets(s2.Namespace).Update(s2)
+	s3, err := v.netIfc.Subnets(s2.Namespace).UpdateStatus(s2)
 	tAfter := time.Now()
 	subnetUpdateHistograms.With(prometheus.Labels{"err": FormatErrVal(err != nil), "statusErr": FormatErrVal(len(validationErrors) > 0)}).Observe(tAfter.Sub(tBefore).Seconds())
 	switch {

--- a/staging/kos/pkg/registry/network/iplock/etcd.go
+++ b/staging/kos/pkg/registry/network/iplock/etcd.go
@@ -25,7 +25,7 @@ import (
 )
 
 // NewREST returns a RESTStorage object that will work against API services.
-func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*registry.REST, error) {
+func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *registry.REST {
 	strategy := NewStrategy(scheme)
 
 	store := &genericregistry.Store{
@@ -40,7 +40,7 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*reg
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: GetAttrs}
 	if err := store.CompleteWithOptions(options); err != nil {
-		return nil, err
+		panic(err)
 	}
-	return &registry.REST{store}, nil
+	return &registry.REST{store, []string{"all", "kos"}, []string{"ipl"}}
 }

--- a/staging/kos/pkg/registry/registry.go
+++ b/staging/kos/pkg/registry/registry.go
@@ -17,24 +17,73 @@ limitations under the License.
 package registry
 
 import (
-	"fmt"
+	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 )
 
-// REST implements a RESTStorage for API services against etcd
+// REST implements rest.Storage and a bunch of other interfaces based
+// on inheritance from the Store, plus CategoriesProvider and
+// ShortNamesProvider --- all based on storing API objects in etcd.
 type REST struct {
 	*genericregistry.Store
+	Categorys  []string
+	ShortNamez []string
 }
 
-// RESTInPeace is just a simple function that panics on error.
-// Otherwise returns the given storage object. It is meant to be
-// a wrapper for network registries.
-func RESTInPeace(storage rest.StandardStorage, err error) rest.StandardStorage {
-	if err != nil {
-		err = fmt.Errorf("unable to create REST storage for a resource due to %v, will die", err)
-		panic(err)
-	}
-	return storage
+// Inherits New() from the Store.
+var _ rest.Storage = &REST{}
+
+// Inherits a lot of methods from the Store.  A &REST also implements
+// Exporter, Scoper, TableConvertor, Creater, Updater by inheritance
+// from the Store.
+var _ rest.StandardStorage = &REST{}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return r.ShortNamez
+}
+
+// Implement CategoriesProvider
+var _ rest.CategoriesProvider = &REST{}
+
+// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
+func (r *REST) Categories() []string {
+	return r.Categorys
+}
+
+func (r *REST) WithCategories(categories []string) *REST {
+	r.Categorys = categories
+	return r
+}
+
+// StatusREST implements the REST endpoint for changing the status of an object
+type StatusREST struct {
+	Stor *genericregistry.Store
+}
+
+var _ rest.Storage = &StatusREST{}
+var _ rest.Getter = &StatusREST{}
+var _ rest.Updater = &StatusREST{}
+
+func (r *StatusREST) New() runtime.Object {
+	return r.Stor.New()
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return r.Stor.Get(ctx, name, options)
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
+	// subresources should never allow create on update.
+	return r.Stor.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }


### PR DESCRIPTION
Also introduce shortnames for the resources, and put them in the
categories "all" and "kos".

Also tighten up the RBAC roles a little, and add the missing
privileges to update/patch status.

Distinguish not-found from other errors, accurately

Also cease initializing HistogramVec members for errors.