### PR TITLE
[DO-NOT-MERGE] Separate NetworkAttachments lifecycle latency Prometheus metrics

### DIFF
--- a/staging/kos/cmd/attachment-tput-driver/tracking_histograms.go
+++ b/staging/kos/cmd/attachment-tput-driver/tracking_histograms.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type TrackingHistogram interface {
+	prometheus.Histogram
+	ObserveAt(x float64, ns, name string)
+	DumpToLog()
+	DumpToLogWLabels(labels string)
+}
+
+type trackingHistogram struct {
+	prometheus.Histogram
+	name string
+
+	statMu  sync.RWMutex
+	maxX    float64
+	maxNS   string
+	maxName string
+}
+
+var _ TrackingHistogram = &trackingHistogram{}
+
+func (th *trackingHistogram) ObserveAt(x float64, ns, name string) {
+	th.Histogram.Observe(x)
+	th.statMu.Lock()
+	defer th.statMu.Unlock()
+	if x > th.maxX {
+		th.maxX = x
+		th.maxNS = ns
+		th.maxName = name
+		// fmt.Printf("%s: maxX=%g, maxAt=%s/%s\n", th.name, th.maxX, th.maxNS, th.maxName)
+	}
+}
+
+func (th *trackingHistogram) DumpToLog() {
+	th.statMu.RLock()
+	defer th.statMu.RUnlock()
+	glog.Warningf("TrackingHistogram stats: histogram=%s, maxX=%g, maxAt=%s/%s",
+		th.name,
+		th.maxX,
+		th.maxNS,
+		th.maxName)
+}
+
+func (th *trackingHistogram) DumpToLogWLabels(labels string) {
+	th.statMu.RLock()
+	defer th.statMu.RUnlock()
+	glog.Warningf("TrackingHistogram stats: histogram=%s, labels=%s, maxX=%g, maxAt=%s/%s",
+		th.name,
+		labels,
+		th.maxX,
+		th.maxNS,
+		th.maxName)
+}
+
+func NewTrackingHistogram(opts prometheus.HistogramOpts) TrackingHistogram {
+	return &trackingHistogram{
+		name:      opts.Name,
+		Histogram: prometheus.NewHistogram(opts),
+	}
+}
+
+type TrackingHistogramVec interface {
+	With(prometheus.Labels) TrackingHistogram
+	DumpToLog()
+	List() []prometheus.Collector
+}
+
+type trackingHistogramVec struct {
+	sync.RWMutex
+	labels2UsedTrackingHistogram   map[string]TrackingHistogram
+	labels2UnusedTrackingHistogram map[string]TrackingHistogram
+}
+
+var _ TrackingHistogramVec = &trackingHistogramVec{}
+
+func (thv *trackingHistogramVec) List() []prometheus.Collector {
+	thv.RLock()
+	defer thv.RUnlock()
+
+	res := make([]prometheus.Collector, 0, len(thv.labels2UnusedTrackingHistogram)+len(thv.labels2UsedTrackingHistogram))
+	for _, th := range thv.labels2UnusedTrackingHistogram {
+		res = append(res, th)
+	}
+	for _, th := range thv.labels2UsedTrackingHistogram {
+		res = append(res, th)
+	}
+	return res
+}
+
+func (thv *trackingHistogramVec) DumpToLog() {
+	thv.RLock()
+	defer thv.RUnlock()
+
+	for labels, th := range thv.labels2UsedTrackingHistogram {
+		th.DumpToLogWLabels(labels)
+	}
+}
+
+func (thv *trackingHistogramVec) With(l prometheus.Labels) TrackingHistogram {
+	labels := joinLabels(l)
+
+	thv.Lock()
+	defer thv.Unlock()
+
+	if th, found := thv.labels2UnusedTrackingHistogram[labels]; found {
+		delete(thv.labels2UnusedTrackingHistogram, labels)
+		thv.labels2UsedTrackingHistogram[labels] = th
+		return th
+	}
+	if th, found := thv.labels2UsedTrackingHistogram[labels]; found {
+		return th
+	}
+	panic(fmt.Sprintf("no histogram with labels %s was found", labels))
+}
+
+// NewTrackingHistogramVec returns a TrackingHistogramVec that mimicks a
+// Prometheus HistogramVec, in the sense that invoking `.With(labels)` on the
+// returned TrackingHistogramVec returns the appropriate Histogram. However,
+// unlike for a real Prometheus HistogramVec, the set of Histograms in the
+// returned TrackingHistogramVec is fixed and determined by `potentialLabels` at
+// creation time. This is done because maintaining a dynamic set of Histograms
+// would require TrackingHistogramVec implementers to implement interfaces
+// defined in the Prometheus package, which is far from trivial. Notice that the
+// chosen approach works well only if the number of managed histograms is small.
+//
+// For each item `pl` in `potentialLabels` a Prometheus Histogram whose const
+// labels are obtained by merging the labels in `opts` and `pl` is created. `pl`
+// is turned into const labels because all the Histograms have the same name and
+// the same label names, and registering multiple metrics with the same name and
+// the same non-const label names is disallowed; OTOH, registering multiple
+// metrics with the same name and same const label names (but different values)
+// is allowed.
+func NewTrackingHistogramVec(opts prometheus.HistogramOpts, potentialLabels []prometheus.Labels) TrackingHistogramVec {
+	labels2TrackingHistogram := map[string]TrackingHistogram{}
+	for _, pl := range potentialLabels {
+		labels := joinLabels(pl)
+		if _, found := labels2TrackingHistogram[labels]; found {
+			panic("labels can occurr at most once but " + labels + " appear more than once")
+		}
+		optsC := opts
+		optsC.ConstLabels = make(prometheus.Labels, len(opts.ConstLabels))
+		for lName, lVal := range opts.ConstLabels {
+			optsC.ConstLabels[lName] = lVal
+		}
+		for lName, lVal := range pl {
+			if _, found := optsC.ConstLabels[lName]; found {
+				panic("label names can appear in at most one of const and potential labels, \"" +
+					lName +
+					"\" was found in both")
+			}
+			optsC.ConstLabels[lName] = lVal
+		}
+		labels2TrackingHistogram[labels] = NewTrackingHistogram(optsC)
+	}
+	return &trackingHistogramVec{
+		labels2UnusedTrackingHistogram: labels2TrackingHistogram,
+		labels2UsedTrackingHistogram:   map[string]TrackingHistogram{},
+	}
+}
+
+// joinLabels returns the content of `labels` in the form
+// "l1Name=l1Val, ... , lnName=lnVal", where liName is
+// the ith label name in alphabetical order.
+func joinLabels(labels prometheus.Labels) string {
+	labelsBuf := make([]string, 0, len(labels))
+	for lName, lVal := range labels {
+		labelsBuf = append(labelsBuf, lName+"="+lVal)
+	}
+	sort.Strings(labelsBuf)
+	return strings.Join(labelsBuf, ", ")
+}

--- a/staging/kos/cmd/controller-manager/main.go
+++ b/staging/kos/cmd/controller-manager/main.go
@@ -48,6 +48,9 @@ const (
 
 	// The HTTP path under which the scraping endpoint ("/metrics") is served.
 	metricsPath = "/metrics"
+
+	// Prometheus scrape interval.
+	scrapeInterval = 10 * time.Second
 )
 
 func main() {
@@ -105,6 +108,11 @@ func main() {
 	go func() {
 		klog.Errorf("In-process HTTP server crashed: %s", http.ListenAndServe(metricsAddr, nil).Error())
 	}()
+
+	// Wait longer than the Prometheus scrape interval so that bursty metrics
+	// are scraped before they reach their final values (otherwise PromQL's
+	// rate() will miss their changes).
+	time.Sleep(scrapeInterval + time.Second)
 
 	ctx.sharedInformers.Start(ctx.stop)
 	klog.V(2).Info("Informers started.")

--- a/staging/kos/pkg/apis/network/types.go
+++ b/staging/kos/pkg/apis/network/types.go
@@ -330,6 +330,48 @@ type NetworkAttachmentStatus struct {
 	// interface was first created.
 	// +optional
 	PostCreateExecReport *ExecReport
+
+	// Whether the NetworkAttachment was created before the IPAM controller
+	// started. An empty value is equivalent to "unknown".
+	// +optional
+	WaitedForIPAM WaitedForStatus
+
+	// Whether `IPv4` was set before the Connection Agent on `spec.Node`
+	// started. An empty value is equivalent to "unknown".
+	// +optional
+	WaitedForCA WaitedForStatus
+}
+
+type WaitedForStatus string
+
+const (
+	WaitedForTrue  WaitedForStatus = "true"
+	WaitedForFalse WaitedForStatus = "false"
+	// equivalent to ""
+	WaitedForUnknown WaitedForStatus = "unknown"
+)
+
+func (w WaitedForStatus) String() string {
+	if w == "" {
+		return string(WaitedForUnknown)
+	}
+	return string(w)
+}
+
+func (w1 WaitedForStatus) Equal(w2 WaitedForStatus) bool {
+	if w1 == w2 ||
+		w1 == WaitedForUnknown && w2 == "" ||
+		w1 == "" && w2 == WaitedForUnknown {
+		return true
+	}
+	return false
+}
+
+func BuildWaitedForStatus(waiter, event time.Time) WaitedForStatus {
+	if waiter.Before(event) {
+		return WaitedForTrue
+	}
+	return WaitedForFalse
 }
 
 type NetworkAttachmentErrors struct {

--- a/staging/kos/pkg/apis/network/v1alpha1/types.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/types.go
@@ -330,6 +330,48 @@ type NetworkAttachmentStatus struct {
 	// interface was first created.
 	// +optional
 	PostCreateExecReport *ExecReport `json:"postCreateExecReport,omitempty" protobuf:"bytes,8,opt,name=postCreateExecReport"`
+
+	// Whether the NetworkAttachment was created before the IPAM controller
+	// started. An empty value is equivalent to "unknown".
+	// +optional
+	WaitedForIPAM WaitedForStatus `json:"waitedForIPAM,omitempty" protobuf:"bytes,9,opt,name=waitedForIPAM"`
+
+	// Whether `IPv4` was set before the Connection Agent on `spec.Node`
+	// started. An empty value is equivalent to "unknown".
+	// +optional
+	WaitedForCA WaitedForStatus `json:"waitedForCA,omitempty" protobuf:"bytes,10,opt,name=waitedForCA"`
+}
+
+type WaitedForStatus string
+
+const (
+	WaitedForTrue  WaitedForStatus = "true"
+	WaitedForFalse WaitedForStatus = "false"
+	// equivalent to ""
+	WaitedForUnknown WaitedForStatus = "unknown"
+)
+
+func (w WaitedForStatus) String() string {
+	if w == "" {
+		return string(WaitedForUnknown)
+	}
+	return string(w)
+}
+
+func (w1 WaitedForStatus) Equal(w2 WaitedForStatus) bool {
+	if w1 == w2 ||
+		w1 == WaitedForUnknown && w2 == "" ||
+		w1 == "" && w2 == WaitedForUnknown {
+		return true
+	}
+	return false
+}
+
+func BuildWaitedForStatus(waiter, event time.Time) WaitedForStatus {
+	if waiter.Before(event) {
+		return WaitedForTrue
+	}
+	return WaitedForFalse
 }
 
 type NetworkAttachmentErrors struct {

--- a/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
@@ -441,6 +441,8 @@ func autoConvert_v1alpha1_NetworkAttachmentStatus_To_network_NetworkAttachmentSt
 	out.IfcName = in.IfcName
 	out.HostIP = in.HostIP
 	out.PostCreateExecReport = (*network.ExecReport)(unsafe.Pointer(in.PostCreateExecReport))
+	out.WaitedForIPAM = network.WaitedForStatus(in.WaitedForIPAM)
+	out.WaitedForCA = network.WaitedForStatus(in.WaitedForCA)
 	return nil
 }
 
@@ -460,6 +462,8 @@ func autoConvert_network_NetworkAttachmentStatus_To_v1alpha1_NetworkAttachmentSt
 	out.IfcName = in.IfcName
 	out.HostIP = in.HostIP
 	out.PostCreateExecReport = (*ExecReport)(unsafe.Pointer(in.PostCreateExecReport))
+	out.WaitedForIPAM = WaitedForStatus(in.WaitedForIPAM)
+	out.WaitedForCA = WaitedForStatus(in.WaitedForCA)
 	return nil
 }
 

--- a/staging/kos/pkg/controllers/connectionagent/attachment_execs.go
+++ b/staging/kos/pkg/controllers/connectionagent/attachment_execs.go
@@ -108,8 +108,8 @@ func (c *ConnectionAgent) runCommand(attNSN k8stypes.NamespacedName, ifc netfabr
 	}
 	exitStatusStr := strconv.FormatInt(int64(cr.ExitStatus), 10)
 	lgComplaintsStr := strconv.FormatInt(int64(bits.Len(complaints)-1), 10)
-	c.attachmentExecDurationHistograms.With(prometheus.Labels{"what": what, "exitStatus": exitStatusStr, "lgComplaints": lgComplaintsStr}).Observe(stopTime.Sub(startTime).Seconds())
-	c.attachmentExecStatusCounts.With(prometheus.Labels{"what": what, "exitStatus": exitStatusStr, "lgComplaints": lgComplaintsStr}).Inc()
+	c.attachmentExecDurationHistograms.With(prometheus.Labels{whatLabel: what, exitStatusLabel: exitStatusStr, lgComplaintsLabel: lgComplaintsStr}).Observe(stopTime.Sub(startTime).Seconds())
+	c.attachmentExecStatusCounts.With(prometheus.Labels{whatLabel: what, exitStatusLabel: exitStatusStr, lgComplaintsLabel: lgComplaintsStr}).Inc()
 	klog.V(4).Infof("Exec report: att=%s, vni=%06x, ipv4=%s, ifcName=%s, mac=%s, what=%s, report=%#+v", attNSN, ifc.VNI, ifc.GuestIP, ifc.Name, ifc.GuestMAC, what, cr)
 	if setExecReport != nil {
 		setExecReport(cr)

--- a/staging/kos/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/kos/pkg/generated/openapi/zz_generated.openapi.go
@@ -2880,6 +2880,20 @@ func schema_pkg_apis_network_v1alpha1_NetworkAttachmentStatus(ref common.Referen
 							Ref:         ref("k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.ExecReport"),
 						},
 					},
+					"waitedForIPAM": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether the NetworkAttachment was created before the IPAM controller started. An empty value is equivalent to \"unknown\".",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"waitedForCA": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether `IPv4` was set before the Connection Agent on `spec.Node` started. An empty value is equivalent to \"unknown\".",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/staging/kos/pkg/registry/network/networkattachment/strategy.go
+++ b/staging/kos/pkg/registry/network/networkattachment/strategy.go
@@ -168,10 +168,18 @@ func (networkattachmentStatusStrategy) PrepareForUpdate(ctx context.Context, obj
 	newNA.Spec = oldNA.Spec
 	newNA.ExtendedObjectMeta = oldNA.ExtendedObjectMeta
 	now := network.Now()
-	if oldNA.Status.LockUID != newNA.Status.LockUID || oldNA.Status.AddressVNI != newNA.Status.AddressVNI || oldNA.Status.IPv4 != newNA.Status.IPv4 || !SliceOfStringEqual(oldNA.Status.Errors.IPAM, newNA.Status.Errors.IPAM) {
+	if oldNA.Status.LockUID != newNA.Status.LockUID ||
+		oldNA.Status.AddressVNI != newNA.Status.AddressVNI ||
+		oldNA.Status.IPv4 != newNA.Status.IPv4 ||
+		!oldNA.Status.WaitedForIPAM.Equal(newNA.Status.WaitedForIPAM) ||
+		!SliceOfStringEqual(oldNA.Status.Errors.IPAM, newNA.Status.Errors.IPAM) {
 		newNA.Writes = newNA.Writes.SetWrite(network.NASectionAddr, now)
 	}
-	if oldNA.Status.MACAddress != newNA.Status.MACAddress || oldNA.Status.IfcName != newNA.Status.IfcName || oldNA.Status.HostIP != newNA.Status.HostIP || !SliceOfStringEqual(oldNA.Status.Errors.Host, newNA.Status.Errors.Host) {
+	if oldNA.Status.MACAddress != newNA.Status.MACAddress ||
+		oldNA.Status.IfcName != newNA.Status.IfcName ||
+		oldNA.Status.HostIP != newNA.Status.HostIP ||
+		!oldNA.Status.WaitedForCA.Equal(newNA.Status.WaitedForCA) ||
+		!SliceOfStringEqual(oldNA.Status.Errors.Host, newNA.Status.Errors.Host) {
 		newNA.Writes = newNA.Writes.SetWrite(network.NASectionImpl, now)
 	}
 	if !oldNA.Status.PostCreateExecReport.Equiv(newNA.Status.PostCreateExecReport) {


### PR DESCRIPTION
This PR breaks down the Prometheus metrics that track the latencies from creation of NetworkAttachments (NA) to relevant lifecycle events (e.g. assignment of a virtual IP address, creation of a network interface on the node the NA is bound to).

Latencies are broken down on whether the NA was created before the IPAM controller was running, on whether the NA was given an address before its local Connection Agent (LCA) was running, on whether the NA became implementable (virtual IP and MAC addresses written in status) on the remote nodes before the remote Connection Agents (RCA) on such nodes were running, and on whether the NA became implementable on the remote nodes before it was relevant (i.e. first NA with same VNI is created on remote nodes) on such nodes.

Besides tracking metrics for the happy cases (i.e. all controllers always running), this PR currently comprises metrics that measure the latencies from NA creation to relevant lifecycle events even in the case of failures/downtimes of controllers (i.e. there's a metric that tracks the latency from NA creation to virtual IP assignment for the case were the IPAM was not running when the NA was created).
That was indeed my initial idea and is still in this PR for discussion ([WIP] will be removed after that discussion), but I now think that tracking latencies for those unhappy cases is not worth it, because those are the latencies that are observed when rare(ish), undesired events happen. We're not really interested in knowing their values. We only care about the values for the happy cases. What's more, measuring the latencies for the unhappy cases is difficult/costly. I now favor a PR which is less than this one: we should keep all the "infrastructure" (e.g. NA's status fields) that allow discerning the happy cases from the unhappy ones, and use this ability to record latencies for the happy cases and ignore latencies for unhappy ones.
Follows an example illustrating why tracking latencies for unhappy cases is difficult/costly.
Consider the histogram (part of a HistogramVec) that tracks the latency from NA creation to virtual IP assignment for the case were the NA is created before the IPAM controller starts. When the IPAM starts, it will process in burst all pre-existing NAs (among which there are all those without a virtual IP). This means that ALL the observations on the aforementioned histogram will take place in a very short amount of time. This is shortly after the IPAM starts and likely BEFORE the first Prometheus scrape. This means Prometheus' first scrape will already see the histogram with all of its observations, hence PromQL `rate()` will completely miss the increment, and so will Grafana plots. Currently this PR uses a workaround: it makes the metrics for the unhappy cases "visible" to Prometheus with a call to  `.With(<histogram labels>)`, and then sleeps for a time interval shortly longer than Prometheus scrape period immediately after the metrics start being served, to make sure Prometheus' first scrape sees the histogram with no observations. Besides slowing controllers boot time and not being resilient to changes to the Prometheus scrape interval, this solution could challenge Prometheus scalability, because all the metrics for the unhappy cases are defined (hence scraped and stored) eagerly and each CA has a fair amount of them, while the vast majority of such metrics will never see an observation and need not being defined (and scraped and stored).

This PR does not further break down NA lifecycle latency metrics on whether the NA had to wait for a virtual IP address because its subnet became valid after the NA was created. This PR does not break down metrics for the latency from subnet creation to subnet validation on whether the subnet was created before the validator was running. These two additions are left for a follow-up PR.

**Note**: This PR does not update Grafana dashboards in this repo, some of such dashboards are now broken. There's a [parallel PR](https://github.com/MikeSpreitzer/kos-test/pull/11) in `kos-test` that updates the Dashboards there. Soon there will be an effort to unify the dashboards here and in kos-test under a single-repo, that should fix the broken dashboards.

Edit: Notice that the PR comprises small bug fixes and tweaks that are unrelated to the main goal.