### PR TITLE
More observability of address exhaustion

### DIFF
--- a/staging/kos/pkg/apis/network/types.go
+++ b/staging/kos/pkg/apis/network/types.go
@@ -221,12 +221,17 @@ type NetworkAttachmentStatus struct {
 	// +optional
 	Errors NetworkAttachmentErrors
 
+	// AddressContention indicates whether the address assignment was
+	// delayed due to not enough addresses being available at first.
+	AddressContention bool
+
 	// LockUID is the UID of the IPLock object holding this attachment's
 	// IP address, or the empty string when there is no address.
 	// This field is a private detail of the implementation, not really
 	// part of the public API.
 	// +optional
 	LockUID string
+
 	// AddressVNI is the VNI associated with this attachment's
 	// IP address assignment, or the empty string when there is no address.
 	// +optional

--- a/staging/kos/pkg/apis/network/v1alpha1/types.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/types.go
@@ -221,12 +221,17 @@ type NetworkAttachmentStatus struct {
 	// +optional
 	Errors NetworkAttachmentErrors `json:"errors,omitempty" protobuf:"bytes,1,opt,name=errors"`
 
+	// AddressContention indicates whether the address assignment was
+	// delayed due to not enough addresses being available at first.
+	AddressContention bool `json:"addressDelayed,omitempty" protbuf:"bytes,9,opt,name=addressDelayed"`
+
 	// LockUID is the UID of the IPLock object holding this attachment's
 	// IP address, or the empty string when there is no address.
 	// This field is a private detail of the implementation, not really
 	// part of the public API.
 	// +optional
 	LockUID string `json:"lockUID,omitempty" protobuf:"bytes,2,opt,name=lockUID"`
+
 	// AddressVNI is the VNI associated with this attachment's
 	// IP address assignment, or the empty string when there is no address.
 	// +optional

--- a/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
@@ -424,6 +424,7 @@ func autoConvert_v1alpha1_NetworkAttachmentStatus_To_network_NetworkAttachmentSt
 	if err := Convert_v1alpha1_NetworkAttachmentErrors_To_network_NetworkAttachmentErrors(&in.Errors, &out.Errors, s); err != nil {
 		return err
 	}
+	out.AddressContention = in.AddressContention
 	out.LockUID = in.LockUID
 	out.AddressVNI = in.AddressVNI
 	out.IPv4 = in.IPv4
@@ -443,6 +444,7 @@ func autoConvert_network_NetworkAttachmentStatus_To_v1alpha1_NetworkAttachmentSt
 	if err := Convert_network_NetworkAttachmentErrors_To_v1alpha1_NetworkAttachmentErrors(&in.Errors, &out.Errors, s); err != nil {
 		return err
 	}
+	out.AddressContention = in.AddressContention
 	out.LockUID = in.LockUID
 	out.AddressVNI = in.AddressVNI
 	out.IPv4 = in.IPv4

--- a/staging/kos/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/kos/pkg/generated/openapi/zz_generated.openapi.go
@@ -2831,6 +2831,13 @@ func schema_pkg_apis_network_v1alpha1_NetworkAttachmentStatus(ref common.Referen
 							Ref: ref("k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.NetworkAttachmentErrors"),
 						},
 					},
+					"addressDelayed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AddressContention indicates whether the address assignment was delayed due to not enough addresses being available at first.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"lockUID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LockUID is the UID of the IPLock object holding this attachment's IP address, or the empty string when there is no address. This field is a private detail of the implementation, not really part of the public API.",

--- a/staging/kos/pkg/registry/network/networkattachment/strategy.go
+++ b/staging/kos/pkg/registry/network/networkattachment/strategy.go
@@ -168,7 +168,11 @@ func (networkattachmentStatusStrategy) PrepareForUpdate(ctx context.Context, obj
 	newNA.Spec = oldNA.Spec
 	newNA.ExtendedObjectMeta = oldNA.ExtendedObjectMeta
 	now := network.Now()
-	if oldNA.Status.LockUID != newNA.Status.LockUID || oldNA.Status.AddressVNI != newNA.Status.AddressVNI || oldNA.Status.IPv4 != newNA.Status.IPv4 || !SliceOfStringEqual(oldNA.Status.Errors.IPAM, newNA.Status.Errors.IPAM) {
+	if oldNA.Status.LockUID != newNA.Status.LockUID ||
+		oldNA.Status.AddressVNI != newNA.Status.AddressVNI ||
+		oldNA.Status.IPv4 != newNA.Status.IPv4 ||
+		oldNA.Status.AddressContention != newNA.Status.AddressContention ||
+		!SliceOfStringEqual(oldNA.Status.Errors.IPAM, newNA.Status.Errors.IPAM) {
 		newNA.Writes = newNA.Writes.SetWrite(network.NASectionAddr, now)
 	}
 	if oldNA.Status.MACAddress != newNA.Status.MACAddress || oldNA.Status.IfcName != newNA.Status.IfcName || oldNA.Status.HostIP != newNA.Status.HostIP || !SliceOfStringEqual(oldNA.Status.Errors.Host, newNA.Status.Errors.Host) {


### PR DESCRIPTION
Better log messages.

Split the create-to-xxx latency histograms according to whether there
were attempts that failed due to lack of available addresses.

Add a histogram of whether each attempt to pick an address had that
problem.

Split a couple of histograms in the attachment-tput-driver.