### PR TITLE
Split metrics on last client write

### DIFF
--- a/staging/kos/cmd/attachment-tput-driver/main.go
+++ b/staging/kos/cmd/attachment-tput-driver/main.go
@@ -560,7 +560,7 @@ func (slot *Slot) close(VNI uint32, nsName string) *netv1a1.NetworkAttachment {
 		}
 		c2t.ObserveAt(slot.testedTime.Sub(slot.preCreateTime).Seconds(), nsName, slot.natt.Name)
 		r2t.ObserveAt(slot.testedTime.Sub(slot.readyTime).Seconds(), nsName, slot.natt.Name)
-		testCounts.With(prometheus.Labels{esLabel: strconv.FormatInt(int64(slot.testES), 10), lgComplaintsLabel: strconv.FormatInt(int64(slot.testLgComplaints), 10), fullLabel: strconv.FormatBool(slot.fullTest)}).Inc()
+		testCounts.WithLabelValues(strconv.FormatInt(int64(slot.testES), 10), strconv.FormatInt(int64(slot.testLgComplaints), 10), strconv.FormatBool(slot.fullTest)).Inc()
 	}
 	if slot.addressedTime == (time.Time{}) {
 		glog.Infof("Attachment got no address: attachment=%s/%s, VNI=%06x, node=%s\n", nsName, slot.currentAttachmentName, VNI, slot.currentNodeName)

--- a/staging/kos/pkg/apis/network/types.go
+++ b/staging/kos/pkg/apis/network/types.go
@@ -221,6 +221,11 @@ type NetworkAttachmentStatus struct {
 	// +optional
 	Errors NetworkAttachmentErrors
 
+	// SubnetCreationTime is the API server write time of the SubnetSectionSpec
+	// of the subnet identified by NetworkAttachmentSpec.Subnet.
+	// +optional
+	SubnetCreationTime metav1.MicroTime
+
 	// AddressContention indicates whether the address assignment was
 	// delayed due to not enough addresses being available at first.
 	AddressContention bool

--- a/staging/kos/pkg/apis/network/v1alpha1/types.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/types.go
@@ -221,39 +221,44 @@ type NetworkAttachmentStatus struct {
 	// +optional
 	Errors NetworkAttachmentErrors `json:"errors,omitempty" protobuf:"bytes,1,opt,name=errors"`
 
+	// SubnetCreationTime is the API server write time of the SubnetSectionSpec
+	// of the subnet identified by NetworkAttachmentSpec.Subnet.
+	// +optional
+	SubnetCreationTime metav1.MicroTime `json:"subnetCreationTime,omitempty" protobuf:"bytes,2,opt,name=subnetCreationTime"`
+
 	// AddressContention indicates whether the address assignment was
 	// delayed due to not enough addresses being available at first.
-	AddressContention bool `json:"addressDelayed,omitempty" protbuf:"bytes,9,opt,name=addressDelayed"`
+	AddressContention bool `json:"addressContention,omitempty" protobuf:"bytes,3,opt,name=addressContention"`
 
 	// LockUID is the UID of the IPLock object holding this attachment's
 	// IP address, or the empty string when there is no address.
 	// This field is a private detail of the implementation, not really
 	// part of the public API.
 	// +optional
-	LockUID string `json:"lockUID,omitempty" protobuf:"bytes,2,opt,name=lockUID"`
+	LockUID string `json:"lockUID,omitempty" protobuf:"bytes,4,opt,name=lockUID"`
 
 	// AddressVNI is the VNI associated with this attachment's
 	// IP address assignment, or the empty string when there is no address.
 	// +optional
-	AddressVNI uint32 `json:"addressVNI,omitempty" protobuf:"bytes,3,opt,name=addressVNI"`
+	AddressVNI uint32 `json:"addressVNI,omitempty" protobuf:"bytes,5,opt,name=addressVNI"`
 
 	// IPv4 is non-empty when an address has been assigned.
 	// +optional
-	IPv4 string `json:"ipv4,omitempty" protobuf:"bytes,4,opt,name=ipv4"`
+	IPv4 string `json:"ipv4,omitempty" protobuf:"bytes,6,opt,name=ipv4"`
 
 	// MACAddress is non-empty while there is a corresponding Linux
 	// network interface on the host.
 	// +optional
-	MACAddress string `json:"macAddress,omitempty" protobuf:"bytes,5,opt,name=macAddress"`
+	MACAddress string `json:"macAddress,omitempty" protobuf:"bytes,7,opt,name=macAddress"`
 
 	// IfcName is the name of the network interface that implements this
 	// attachment on its node, or the empty string to indicate no
 	// implementation.
 	// +optional
-	IfcName string `json:"ifcName,omitempty" protobuf:"bytes,6,opt,name=ifcname"`
+	IfcName string `json:"ifcName,omitempty" protobuf:"bytes,8,opt,name=ifcname"`
 	// HostIP is the IP address of the node the attachment is bound to.
 	// +optional
-	HostIP string `json:"hostIP,omitempty" protobuf:"bytes,7,opt,name=hostIP"`
+	HostIP string `json:"hostIP,omitempty" protobuf:"bytes,9,opt,name=hostIP"`
 
 	// PostCreateExecReport, if non-nil, reports on the run of the
 	// PostCreateExec that was launched when the Linux network
@@ -266,7 +271,7 @@ type NetworkAttachmentStatus struct {
 	// PostCreateExec of the attachment for whom the Linux network
 	// interface was first created.
 	// +optional
-	PostCreateExecReport *ExecReport `json:"postCreateExecReport,omitempty" protobuf:"bytes,8,opt,name=postCreateExecReport"`
+	PostCreateExecReport *ExecReport `json:"postCreateExecReport,omitempty" protobuf:"bytes,10,opt,name=postCreateExecReport"`
 }
 
 type NetworkAttachmentErrors struct {

--- a/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/zz_generated.conversion.go
@@ -424,6 +424,7 @@ func autoConvert_v1alpha1_NetworkAttachmentStatus_To_network_NetworkAttachmentSt
 	if err := Convert_v1alpha1_NetworkAttachmentErrors_To_network_NetworkAttachmentErrors(&in.Errors, &out.Errors, s); err != nil {
 		return err
 	}
+	out.SubnetCreationTime = in.SubnetCreationTime
 	out.AddressContention = in.AddressContention
 	out.LockUID = in.LockUID
 	out.AddressVNI = in.AddressVNI
@@ -444,6 +445,7 @@ func autoConvert_network_NetworkAttachmentStatus_To_v1alpha1_NetworkAttachmentSt
 	if err := Convert_network_NetworkAttachmentErrors_To_v1alpha1_NetworkAttachmentErrors(&in.Errors, &out.Errors, s); err != nil {
 		return err
 	}
+	out.SubnetCreationTime = in.SubnetCreationTime
 	out.AddressContention = in.AddressContention
 	out.LockUID = in.LockUID
 	out.AddressVNI = in.AddressVNI

--- a/staging/kos/pkg/apis/network/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/kos/pkg/apis/network/v1alpha1/zz_generated.deepcopy.go
@@ -265,6 +265,7 @@ func (in *NetworkAttachmentSpec) DeepCopy() *NetworkAttachmentSpec {
 func (in *NetworkAttachmentStatus) DeepCopyInto(out *NetworkAttachmentStatus) {
 	*out = *in
 	in.Errors.DeepCopyInto(&out.Errors)
+	in.SubnetCreationTime.DeepCopyInto(&out.SubnetCreationTime)
 	if in.PostCreateExecReport != nil {
 		in, out := &in.PostCreateExecReport, &out.PostCreateExecReport
 		*out = new(ExecReport)

--- a/staging/kos/pkg/apis/network/zz_generated.deepcopy.go
+++ b/staging/kos/pkg/apis/network/zz_generated.deepcopy.go
@@ -265,6 +265,7 @@ func (in *NetworkAttachmentSpec) DeepCopy() *NetworkAttachmentSpec {
 func (in *NetworkAttachmentStatus) DeepCopyInto(out *NetworkAttachmentStatus) {
 	*out = *in
 	in.Errors.DeepCopyInto(&out.Errors)
+	in.SubnetCreationTime.DeepCopyInto(&out.SubnetCreationTime)
 	if in.PostCreateExecReport != nil {
 		in, out := &in.PostCreateExecReport, &out.PostCreateExecReport
 		*out = new(ExecReport)

--- a/staging/kos/pkg/controllers/connectionagent/attachment_execs.go
+++ b/staging/kos/pkg/controllers/connectionagent/attachment_execs.go
@@ -25,8 +25,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -108,8 +106,12 @@ func (c *ConnectionAgent) runCommand(attNSN k8stypes.NamespacedName, ifc netfabr
 	}
 	exitStatusStr := strconv.FormatInt(int64(cr.ExitStatus), 10)
 	lgComplaintsStr := strconv.FormatInt(int64(bits.Len(complaints)-1), 10)
-	c.attachmentExecDurationHistograms.With(prometheus.Labels{"what": what, "exitStatus": exitStatusStr, "lgComplaints": lgComplaintsStr}).Observe(stopTime.Sub(startTime).Seconds())
-	c.attachmentExecStatusCounts.With(prometheus.Labels{"what": what, "exitStatus": exitStatusStr, "lgComplaints": lgComplaintsStr}).Inc()
+	c.attachmentExecDurationHistograms.
+		WithLabelValues(what, exitStatusStr, lgComplaintsStr).
+		Observe(stopTime.Sub(startTime).Seconds())
+	c.attachmentExecStatusCounts.
+		WithLabelValues(what, exitStatusStr, lgComplaintsStr).
+		Inc()
 	klog.V(4).Infof("Exec report: att=%s, vni=%06x, ipv4=%s, ifcName=%s, mac=%s, what=%s, report=%#+v", attNSN, ifc.VNI, ifc.GuestIP, ifc.Name, ifc.GuestMAC, what, cr)
 	if setExecReport != nil {
 		setExecReport(cr)

--- a/staging/kos/pkg/controllers/ipam/ipam.go
+++ b/staging/kos/pkg/controllers/ipam/ipam.go
@@ -836,6 +836,7 @@ func (ctlr *IPAMController) updateNAStatus(ns, name string, att *netv1a1.Network
 	}
 	att2 := att.DeepCopy()
 	att2.Status.Errors.IPAM = statusErrs
+	att2.Status.SubnetCreationTime = k8smetav1.NewMicroTime(subnetCreatTime)
 	att2.Status.AddressContention = nadat.addressContention
 	att2.Status.LockUID = string(lockForStatus.UID)
 	att2.Status.AddressVNI = lockForStatus.VNI

--- a/staging/kos/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/kos/pkg/generated/openapi/zz_generated.openapi.go
@@ -2831,7 +2831,13 @@ func schema_pkg_apis_network_v1alpha1_NetworkAttachmentStatus(ref common.Referen
 							Ref: ref("k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.NetworkAttachmentErrors"),
 						},
 					},
-					"addressDelayed": {
+					"subnetCreationTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SubnetCreationTime is the API server write time of the SubnetSectionSpec of the subnet identified by NetworkAttachmentSpec.Subnet.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
+						},
+					},
+					"addressContention": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AddressContention indicates whether the address assignment was delayed due to not enough addresses being available at first.",
 							Type:        []string{"boolean"},
@@ -2890,7 +2896,7 @@ func schema_pkg_apis_network_v1alpha1_NetworkAttachmentStatus(ref common.Referen
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.ExecReport", "k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.NetworkAttachmentErrors"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime", "k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.ExecReport", "k8s.io/examples/staging/kos/pkg/apis/network/v1alpha1.NetworkAttachmentErrors"},
 	}
 }
 

--- a/staging/kos/pkg/registry/network/networkattachment/strategy.go
+++ b/staging/kos/pkg/registry/network/networkattachment/strategy.go
@@ -172,6 +172,7 @@ func (networkattachmentStatusStrategy) PrepareForUpdate(ctx context.Context, obj
 		oldNA.Status.AddressVNI != newNA.Status.AddressVNI ||
 		oldNA.Status.IPv4 != newNA.Status.IPv4 ||
 		oldNA.Status.AddressContention != newNA.Status.AddressContention ||
+		!(&oldNA.Status.SubnetCreationTime).Equal(&newNA.Status.SubnetCreationTime) ||
 		!SliceOfStringEqual(oldNA.Status.Errors.IPAM, newNA.Status.Errors.IPAM) {
 		newNA.Writes = newNA.Writes.SetWrite(network.NASectionAddr, now)
 	}

--- a/staging/kos/pkg/registry/network/subnet/strategy.go
+++ b/staging/kos/pkg/registry/network/subnet/strategy.go
@@ -150,11 +150,11 @@ func (ss *subnetStrategy) Validate(ctx context.Context, obj runtime.Object) fiel
 func (ss *subnetStrategy) checkNSAndCIDRConflicts(candidate *subnet.Summary) (errs field.ErrorList) {
 	potentialRivals, err := ss.subnetIndexer.ByIndex(subnetVNIIndex, strconv.FormatUint(uint64(candidate.VNI), 10))
 	if err != nil {
-		klog.Errorf("subnetIndexer.ByIndex failed for index %s and vni %d: %s", subnetVNIIndex, candidate.VNI, err.Error())
+		klog.Errorf("subnetIndexer.ByIndex failed for index %s and VNI %06x: %s", subnetVNIIndex, candidate.VNI, err.Error())
 		errs = field.ErrorList{field.InternalError(field.NewPath("spec", "vni"), errors.New("failed to retrieve other subnets with same vni"))}
 		return
 	}
-	klog.V(5).Infof("Found %d subnets with vni %d", len(potentialRivals), candidate.VNI)
+	klog.V(5).Infof("Found %d subnets with VNI %06x", len(potentialRivals), candidate.VNI)
 	// Check whether there are Namespace and CIDR conflicts with other subnets.
 	for _, potentialRival := range potentialRivals {
 		pr, err := subnet.NewSummary(potentialRival)


### PR DESCRIPTION
This PR is the first step towards the changes discussed in #111 .
It splits metrics on the latencies of the lifecycles of NetAtts and subnets (NAs) on the basis of the last client precursor.

This PR self-contained and mergeable, but it's partial. It does not take into account in any way the fact that client precursors could be deletions of API objects as well (as pointed out [here](https://github.com/MikeSpreitzer/kube-examples/pull/111#issuecomment-625897528)).  It does not take into account the fact that implementation of API objects could be delayed because controllers could fail. Let's merge this and do remaining things in follow-up PRs. 