### PR TITLE
Modify `glide.yaml` and run `glide up -v` to fix `hack/update-codegen.sh`

### DIFF
--- a/staging/kos/glide.lock
+++ b/staging/kos/glide.lock
@@ -1,5 +1,5 @@
-hash: 1658ac48a24afb201893c3171272822948e779688ebcf0a5a1b96d0b909a490c
-updated: 2020-06-04T18:00:24.626627-04:00
+hash: 7a35cc6640e1c3f27e735f930858d7a9ca77bce381d126909ebec59234240acf
+updated: 2020-06-08T18:11:56.099756+02:00
 imports:
 - name: github.com/beorn7/perks
   version: 37c8de3658fcb183f997c4e13e8337516ab753e6
@@ -604,7 +604,7 @@ imports:
   - featuregate
   - logs
 - name: k8s.io/gengo
-  version: fb547a11e5e09bfeff19d7a38492100a554fa242
+  version: e0e292d8aa122d458174e1bef5f142b4d0a67a05
   subpackages:
   - args
 - name: k8s.io/klog

--- a/staging/kos/glide.yaml
+++ b/staging/kos/glide.yaml
@@ -70,9 +70,12 @@ import:
   subpackages:
   - pkg/common
 - package: k8s.io/gengo
+  # Pin this commit because it's the last w/o klog/v2 and we're not ready for the switch to klog/v2 yet.
+  version: e0e292d8aa122d458174e1bef5f142b4d0a67a05
   subpackages:
   - args
 - package: k8s.io/klog
+  # When we switch to klog/v2, remove the pin on the commit of k8s.io/gengo.
   version: ~0.3.3
 
 # sample-apiserver main now use k8s.io/component-base, and we follow suit


### PR DESCRIPTION
Modify glide.yaml by pinning the commit of `k8s.io/gengo` to the latest commit that doesn't require `klog/v2`. We're already explicitly asking for a klog version earlier than 2 and we're not ready for the switch yet (it requires upgrading to more recent releases a lot of dependencies), and without this commit `hack/update-codegen.sh` fails with:

vendor/k8s.io/gengo/parser/parse.go:36:2: cannot find package "k8s.io/klog/v2" in any of:
        /Users/matteo/go/src/k8s.io/examples/staging/kos/vendor/k8s.io/klog/v2 (vendor tree)
        /usr/local/go/src/k8s.io/klog/v2 (from $GOROOT)
        /Users/matteo/go/src/k8s.io/klog/v2 (from $GOPATH)