### PR TITLE
Tolerate multiple OvS bridges on the same host

### DIFF
--- a/staging/kos/pkg/networkfabric/ovs/doc.go
+++ b/staging/kos/pkg/networkfabric/ovs/doc.go
@@ -21,13 +21,6 @@ limitations under the License.
 // The fabric is based on an Open vSwitch (OvS) bridge, which gets configured
 // through OpenFlow.
 //
-//******************************************************************************
-// Currently, THE FABRIC DOES NOT WORK IF ANOTHER OvS BRIDGE EXISTS ON THE NODE.
-// DOES NOT WORK means that its behavior is incorrect and undefined. Until this
-// limitation is removed, users must ensure there's no other OvS bridge on the
-// node.
-//******************************************************************************
-//
 // The fabric constructor's creates the OvS bridge and a Linux network Interface
 // configured to act as a VXLAN Tunnel End Point (VTEP), and connects them
 // together. It also installs some default OpenFlow flows in the bridge.


### PR DESCRIPTION
Before this PR the OvS network fabric **does NOT tolerate** the existence of other OvS bridges on its host (besides its own OvS bridge) when listing pre-existing local network interfaces.

"Does not tolerate" means that it considers pre-existing local network interfaces connected to OvS bridges other than its own as connected to its own OvS bridge, and this means that in certain scenarios it can delete such "external" network interfaces.

This PR fixes that behavior: the OvS fabric now only considers pre-existing local network interfaces connected to its own bridge.

This PR is orthogonal to #119. 